### PR TITLE
Parse SamplesPerPixel when reading dimensions from OME-XML

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -519,7 +519,10 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
           z = metadata.getPixelsSizeZ(0).getNumberValue().intValue();
           c = metadata.getPixelsSizeC(0).getNumberValue().intValue();
           t = metadata.getPixelsSizeT(0).getNumberValue().intValue();
+          rgbChannels = metadata.getChannelSamplesPerPixel(
+            0, 0).getNumberValue().intValue();
           planeCount = (z * c * t) / rgbChannels;
+          c /= rgbChannels;
           littleEndian = !metadata.getPixelsBigEndian(0);
         }
         else {


### PR DESCRIPTION
I wouldn't expect this to affect conversions using bioformats2raw, but this will be required to convert pyramids from isyntax2raw that include a ```METADATA.ome.xml``` file.