### PR TITLE
Fix last IFD offset when writing Faas pyramids with --legacy

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -760,7 +760,9 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
     if (legacy) {
       for (int resolution=0; resolution<numberOfResolutions; resolution++) {
         for (int plane=0; plane<planeCount; plane++) {
-          writeIFD(resolution, plane, true);
+          boolean last = (resolution == numberOfResolutions - 1) &&
+            (plane == planeCount -1);
+          writeIFD(resolution, plane, !last);
         }
       }
     }


### PR DESCRIPTION
This should resolve #13.

Without this PR, convert any dataset to N5 using bioformats2raw, then:

```
$ raw2ometiff test.n5 test.tiff --legacy
$ tiffinfo test.tiff
...
TIFFFetchDirectory: Can not read TIFF directory count.
TIFFReadDirectory: Failed to read directory at offset ...
```

With this PR, the same test should not show any warnings.  Files converted without the ```--legacy``` option should be unaffected.