### PR TITLE
Bump n5 to 2.1.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     compile ('ome:formats-bsd:6.2.1')
     // be careful here, this is a newer version of org.json:json than formats-gpl uses
     compile ('org.json:json:20190722')
-    compile ('org.janelia.saalfeldlab:n5:2.1.3')
+    compile ('org.janelia.saalfeldlab:n5:2.1.6')
     compile ('org.janelia.saalfeldlab:n5-blosc:1.0.1')
     compile ('org.janelia.saalfeldlab:n5-zarr:0.0.2-beta')
 }


### PR DESCRIPTION
Similar to https://github.com/glencoesoftware/bioformats2raw/pull/18, this updates the n5 version to allow support for Java 11.