### PR TITLE
Update tile counts when the resolution dimensions are changed

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -415,14 +415,14 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
           int sizeX = metadata.getPixelsSizeX(0).getNumberValue().intValue();
           int sizeY = metadata.getPixelsSizeY(0).getNumberValue().intValue();
           if (descriptor.sizeX != sizeX) {
-              throw new FormatException(String.format(
-                  "Resolution %d dimension mismatch! metadata=%d pyramid=%d",
-                  resolution, descriptor.sizeX, sizeX));
+            throw new FormatException(String.format(
+                "Resolution %d dimension mismatch! metadata=%d pyramid=%d",
+                resolution, descriptor.sizeX, sizeX));
           }
           if (descriptor.sizeY != sizeY) {
-              throw new FormatException(String.format(
-                  "Resolution %d dimension mismatch! metadata=%d pyramid=%d",
-                  resolution, descriptor.sizeY, sizeY));
+            throw new FormatException(String.format(
+                "Resolution %d dimension mismatch! metadata=%d pyramid=%d",
+                resolution, descriptor.sizeY, sizeY));
           }
         }
       }

--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -441,15 +441,6 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
   }
 
   /**
-   * @param resolution the resolution index
-   * @return total scale factor between the given resolution and the full
-   *         resolution image (resolution 0)
-   */
-  private double getScale(int resolution) {
-    return Math.pow(PYRAMID_SCALE, resolution);
-  }
-
-  /**
    * Populate number of channels, pixels types, endianess, etc.
    * based on the first tile
    * @throws IOException

--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -355,7 +355,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
 
     String blockPath = "/" + resolution;
     long[] gridPosition = new long[] {x, y, no};
-    DataBlock block = n5Reader.readBlock(
+    DataBlock<?> block = n5Reader.readBlock(
       blockPath, n5Reader.getDatasetAttributes(blockPath),
       gridPosition);
 
@@ -454,7 +454,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
     interleaved = false;
     rgbChannels = 1;
     String blockPath = "/0";
-    DataBlock block = n5Reader.readBlock(blockPath,
+    DataBlock<?> block = n5Reader.readBlock(blockPath,
       n5Reader.getDatasetAttributes(blockPath), new long[] {0, 0, 0});
     littleEndian = block.toByteBuffer().order() == ByteOrder.LITTLE_ENDIAN;
     if (block instanceof ByteArrayDataBlock) {

--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -553,21 +553,6 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
       LOG.info("Adding metadata for resolution: {}",
         descriptor.resolutionNumber);
 
-      String levelKey =
-        "Image #0 | Level sizes #" + descriptor.resolutionNumber;
-      Object realX = originalMeta.get(levelKey + " | X");
-      Object realY = originalMeta.get(levelKey + " | Y");
-      if (realX != null) {
-        descriptor.sizeX = DataTools.parseDouble(realX.toString()).intValue();
-        descriptor.numberOfTilesX =
-          getTileCount(descriptor.sizeX, descriptor.tileSizeX);
-      }
-      if (realY != null) {
-        descriptor.sizeY = DataTools.parseDouble(realY.toString()).intValue();
-        descriptor.numberOfTilesY =
-          getTileCount(descriptor.sizeY, descriptor.tileSizeY);
-      }
-
       if (descriptor.resolutionNumber == 0) {
         MetadataTools.populateMetadata(
           this.metadata, 0, null, this.littleEndian, "XYCZT",


### PR DESCRIPTION
Fixes #16.

Tested with ```2.isyntax``` locally and it seems to work fine, with no obvious issues opening the OME-TIFF in QuPath 0.2.0-m9.  Probably worth a wider test though to make sure this doesn't inadvertently break other files.