### PR TITLE
Trust RGB channel count from N5 structure over what is in the OME-XML

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -512,10 +512,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
           z = metadata.getPixelsSizeZ(0).getNumberValue().intValue();
           c = metadata.getPixelsSizeC(0).getNumberValue().intValue();
           t = metadata.getPixelsSizeT(0).getNumberValue().intValue();
-          rgbChannels = metadata.getChannelSamplesPerPixel(
-            0, 0).getNumberValue().intValue();
-          planeCount = (z * c * t) / rgbChannels;
-          c /= rgbChannels;
+          planeCount = z * c * t;
           littleEndian = !metadata.getPixelsBigEndian(0);
         }
         else {
@@ -538,6 +535,8 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
     }
 
     describePyramid();
+    planeCount /= rgbChannels;
+    c /= rgbChannels;
 
     for (ResolutionDescriptor descriptor : resolutions) {
       LOG.info("Adding metadata for resolution: {}",


### PR DESCRIPTION
This fixes multi-channel data handling so that what is currently written by ```isyntax2raw``` and ```bioformats2raw``` will be converted correctly. 

Simple test case is ```bf-data-repo/automated-tests/curated/jpeg/big-images/8kx8k.jpg```, which has 3 RGB channels.  ```bioformats2raw 8kx8k.jpg 8kx8k``` will produce 3 planar channels in ```pyramid.n5``` and a ```METADATA.ome.xml``` that indicates 3 RGB channels.  Without this change, ```raw2ometiff 8kx8k 8kx8k.ome.tiff``` will result in an OME-TIFF with a single channel - only the first channel has been converted.  With this change, the same ```raw2ometiff``` command should convert all 3 channels.

The approach here is less aggressive than fully removing ```rgbChannels``` as proposed in https://github.com/glencoesoftware/raw2ometiff/compare/master...chris-allan:fix-legacy?expand=1, and is aimed at handling the outputs of ```isyntax2raw``` and ```bioformats2raw``` as they exist now.  If we choose to remove ```rgbChannels``` entirely, a corresponding change must be made in ```isyntax2raw``` to write planar channels.