### PR TITLE
Check the value of the "bioformats2raw.layout" attribute

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -465,6 +465,11 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
     if (n5Reader == null) {
       throw new FormatException("Could not create an N5 reader");
     }
+    Integer layoutVersion =
+      n5Reader.getAttribute("/", "bioformats2raw.layout", Integer.class);
+    if (layoutVersion == null || layoutVersion != 1) {
+      throw new FormatException("Unsupported version: " + layoutVersion);
+    }
 
     LOG.info("Creating tiled pyramid file {}", this.outputFilePath);
 


### PR DESCRIPTION
Fail fast if the attribute is missing or indicates an unsupported format version.