### PR TITLE
Fix IFD offsets for multi-series data

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -535,15 +535,13 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
 
       s.dimensionLengths[s.dimensionOrder.indexOf("Z") - 2] = s.z;
       s.dimensionLengths[s.dimensionOrder.indexOf("T") - 2] = s.t;
+      s.dimensionLengths[s.dimensionOrder.indexOf("C") - 2] = s.c;
 
       s.rgb = rgb && (s.c == 3) && (s.z * s.t == 1);
       if (!s.rgb) {
         s.planeCount *= s.c;
-        s.dimensionLengths[s.dimensionOrder.indexOf("C") - 2] = s.c;
       }
       else {
-        s.dimensionLengths[s.dimensionOrder.indexOf("C") - 2] = 1;
-
         OMEXMLMetadataRoot root = (OMEXMLMetadataRoot) metadata.getRoot();
         Pixels pixels = root.getImage(seriesIndex).getPixels();
         while (pixels.sizeOfChannelList() > 1) {


### PR DESCRIPTION
Without this change, the IFD list only contained IFDs for the last series written.  Not a problem for single series data, and difficult to spot for multiple series with the same XY dimensions.