### PR TITLE
Add --quality option to set the compression quality

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -149,6 +149,12 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
   String compression = "LZW";
 
   @Option(
+      names = "--quality",
+      description = "Compression quality"
+  )
+  Double compressionQuality;
+
+  @Option(
       names = "--legacy",
       description = "Write a Bio-Formats 5.9.x pyramid instead of OME-TIFF"
   )
@@ -917,6 +923,9 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
     options.height = buffer.length / (options.width * bpp);
     options.bitsPerSample = bpp * 8;
     options.channels = 1;
+    if (compressionQuality != null) {
+      options.quality = compressionQuality;
+    }
 
     byte[] realTile = tiffCompression.compress(buffer, options);
     LOG.debug("    writing {} compressed bytes at {}",


### PR DESCRIPTION
How the quality setting is interpreted depends upon the compression type.
For lossless compression types, this likely won't make a difference.
For ```JPEG-2000 Lossy```, this is the encoding bit rate.

Some initial experimentation with the N5 pyramid converted from ```1.isyntax``` suggests that ```--compression "JPEG-2000 Lossy" --quality 5.0``` doesn't noticeably reduce the file size compared to the default quality of 10.0, but setting the quality to 1.0 or less rapidly reduces the file size.