### PR TITLE
Resolution-based progress bars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ repositories {
 
 dependencies {
     implementation 'info.picocli:picocli:4.2.0'
+    implementation 'me.tongfei:progressbar:0.9.0'
     implementation 'ome:formats-bsd:6.4.0'
     // be careful here, this is a newer version of org.json:json than formats-gpl uses
     implementation 'org.json:json:20190722'

--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -27,6 +27,9 @@ import org.janelia.saalfeldlab.n5.N5FSReader;
 import org.janelia.saalfeldlab.n5.zarr.N5ZarrReader;
 
 import ch.qos.logback.classic.Level;
+import me.tongfei.progressbar.DelegatingProgressBarConsumer;
+import me.tongfei.progressbar.ProgressBar;
+import me.tongfei.progressbar.ProgressBarBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -122,10 +125,21 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
   Path inputDirectory;
 
   @Option(
-      names = "--debug",
-      description = "Turn on debug logging"
+    names = {"--log-level", "--debug"},
+    arity = "0..1",
+    description = "Change logging level; valid values are " +
+      "OFF, ERROR, WARN, INFO, DEBUG, TRACE and ALL. " +
+      "(default: ${DEFAULT-VALUE})",
+    fallbackValue = "DEBUG"
   )
-  boolean debug = false;
+  private volatile String logLevel = "WARN";
+
+  @Option(
+    names = {"-p", "--progress"},
+    description = "Print progress bars during conversion",
+    help = true
+  )
+  private volatile boolean progressBars = false;
 
   @Option(
       names = "--version",
@@ -517,6 +531,26 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
         LOG.info("Converting resolution #{}", resolution);
         ResolutionDescriptor descriptor = s.resolutions.get(resolution);
         int tileCount = descriptor.numberOfTilesY * descriptor.numberOfTilesX;
+
+        final ProgressBar pb;
+        if (progressBars) {
+          ProgressBarBuilder builder = new ProgressBarBuilder()
+            .setInitialMax(tileCount)
+            .setTaskName(String.format("[%d/%d]", s.index, resolution));
+
+          if (!(logLevel.equals("OFF") ||
+            logLevel.equals("ERROR") ||
+            logLevel.equals("WARN")))
+          {
+            builder.setConsumer(new DelegatingProgressBarConsumer(LOG::trace));
+          }
+
+          pb = builder.build();
+        }
+        else {
+          pb = null;
+        }
+
         for (int plane=0; plane<s.planeCount; plane++) {
           int tileIndex = 0;
           // if the resolution has already been calculated,
@@ -583,12 +617,20 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
                   }
                   finally {
                     t1.stop();
+                    if (pb != null) {
+                      pb.step();
+                    }
                   }
                 });
               }
             }
           }
         }
+
+        if (pb != null) {
+          pb.close();
+        }
+
       }
     }
     finally {
@@ -883,12 +925,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
   private void setupLogger() {
     ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger)
       LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-    if (debug) {
-      root.setLevel(Level.DEBUG);
-    }
-    else {
-      root.setLevel(Level.INFO);
-    }
+    root.setLevel(Level.toLevel(logLevel));
   }
 
   /**


### PR DESCRIPTION
Uses http://tongfei.me/progressbar/ to print progress
bars for each resolution to standard out. The default
logging level is set to WARN for optimal display when
there are no issues.


```
(base) /opt/raw2ometiff $./build/install/raw2ometiff/bin/raw2ometiff /tmp/a.ome.zarr/ /tmp/a1.ome.tif

(base) /opt/raw2ometiff $./build/install/raw2ometiff/bin/raw2ometiff /tmp/a.ome.zarr/ /tmp/a1.ome.tif --progress
[0/0] 100% │██████████████████████████████████████████████████████████████████████████████████████│ 1/1 (0:00:00 / 0:00:00)
[0/1] 100% │██████████████████████████████████████████████████████████████████████████████████████│ 1/1 (0:00:00 / 0:00:00)

(base) /opt/raw2ometiff $./build/install/raw2ometiff/bin/raw2ometiff /tmp/a.ome.zarr/ /tmp/a1.ome.tif --progress --log-level=DEBUG
2021-03-11 11:48:10,426 [main] INFO  c.g.p.PyramidFromDirectoryWriter - Creating tiled pyramid file /tmp/a1.ome.tif
2021-03-11 11:48:10,441 [main] DEBUG loci.common.services.ServiceFactory - Loaded properties from: services.properties
...
```