### PR TITLE
Fix progress bar max value when there are multiple planes

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -772,7 +772,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
         final ProgressBar pb;
         if (progressBars) {
           ProgressBarBuilder builder = new ProgressBarBuilder()
-            .setInitialMax(tileCount)
+            .setInitialMax(tileCount * s.planeCount)
             .setTaskName(String.format("[%d/%d]", s.index, resolution));
 
           if (!(logLevel.equals("OFF") ||


### PR DESCRIPTION
To test, compare something like:

```
$ bioformats2raw "test&sizeZ=100.fake" test -p
$ raw2ometiff test test.ome.tiff -p
```

with and without this PR.