### PR TITLE
Proactively check the series count

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -630,6 +630,10 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
 
     int seriesCount = getSeriesCount();
 
+    if (seriesCount < 1) {
+      throw new FormatException("Found no images to convert.  Corrupt input?");
+    }
+
     if (seriesCount > 1 && legacy) {
       LOG.warn("Omitting {} series due to legacy output", seriesCount - 1);
       seriesCount = 1;

--- a/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
@@ -263,6 +263,17 @@ public class ConversionTest {
   }
 
   /**
+   * Test defaults.
+   */
+  @Test
+  public void testSeriesCountCheck() throws Exception {
+    input = fake();
+    assertBioFormats2Raw();
+    Files.delete(output.resolve("0").resolve(".zgroup"));
+    assertTool();
+  }
+
+  /**
    * Test South and East edge padding.
    */
   @Test

--- a/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
@@ -29,6 +29,7 @@ import com.glencoesoftware.pyramid.PyramidFromDirectoryWriter;
 
 import loci.common.DataTools;
 import loci.common.services.ServiceFactory;
+import loci.formats.FormatException;
 import loci.formats.FormatTools;
 import loci.formats.ImageReader;
 import loci.formats.ome.OMEXMLMetadata;
@@ -37,6 +38,7 @@ import loci.formats.tiff.IFD;
 import loci.formats.tiff.IFDList;
 import loci.formats.tiff.TiffParser;
 import picocli.CommandLine;
+import picocli.CommandLine.ExecutionException;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -270,7 +272,14 @@ public class ConversionTest {
     input = fake();
     assertBioFormats2Raw();
     Files.delete(output.resolve("0").resolve(".zgroup"));
-    assertTool();
+    try {
+      assertTool();
+    }
+    catch (ExecutionException e) {
+      // First cause is RuntimeException wrapping the checked FormatException
+      Assert.assertEquals(
+          FormatException.class, e.getCause().getCause().getClass());
+    }
   }
 
   /**


### PR DESCRIPTION
Proactive, defensive check that avoids a deep, unintelligible exception from being thrown if we cannot detect any images in the input data. Exposed by the investigation in #62.