### PR TITLE
Handle symlink as the root directory (Fixes #62)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     // be careful here, this is a newer version of org.json:json than formats-gpl uses
     implementation 'org.json:json:20190722'
     testImplementation 'junit:junit:4.12'
+    testImplementation 'org.apache.commons:commons-lang3:3.12.0'
     testImplementation 'com.glencoesoftware:bioformats2raw:0.3.0-SNAPSHOT'
 }
 

--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -212,6 +212,8 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
 
   @Override
   public Void call() throws Exception {
+    // Resolve symlinks
+    inputDirectory = inputDirectory.toRealPath();
     if (printVersion) {
       printVersion();
       return null;

--- a/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
@@ -241,14 +241,7 @@ public class ConversionTest {
         reader.isLittleEndian());
   }
 
-  /**
-   * Test defaults.
-   */
-  @Test
-  public void testDefaults() throws Exception {
-    input = fake();
-    assertBioFormats2Raw();
-    assertTool();
+  private void assertDefaults() throws Exception {
     ZarrArray series0 = ZarrGroup.open(output.resolve("0")).openArray("0");
     Assert.assertTrue(series0.getNested());
     // Also ensure we're using the latest .zarray metadata
@@ -266,6 +259,31 @@ public class ConversionTest {
 
   /**
    * Test defaults.
+   */
+  @Test
+  public void testDefaults() throws Exception {
+    input = fake();
+    assertBioFormats2Raw();
+    assertTool();
+    assertDefaults();
+  }
+
+  /**
+   * Test symlink as the root.
+   */
+  @Test
+  public void testSymlinkAsRoot() throws Exception {
+    input = fake();
+    assertBioFormats2Raw();
+    Path notASymlink = output.resolveSibling(output.getFileName() + ".old");
+    Files.move(output, notASymlink);
+    Files.createSymbolicLink(output, notASymlink);
+    assertTool();
+    assertDefaults();
+  }
+
+  /**
+   * Test series count check.
    */
   @Test
   public void testSeriesCountCheck() throws Exception {

--- a/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
@@ -40,7 +40,9 @@ import loci.formats.tiff.TiffParser;
 import picocli.CommandLine;
 import picocli.CommandLine.ExecutionException;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -273,6 +275,7 @@ public class ConversionTest {
    */
   @Test
   public void testSymlinkAsRoot() throws Exception {
+    Assume.assumeTrue(SystemUtils.IS_OS_LINUX);
     input = fake();
     assertBioFormats2Raw();
     Path notASymlink = output.resolveSibling(output.getFileName() + ".old");


### PR DESCRIPTION
The root directory may be a symlink. For certain JZarr method calls to complete successfully it is required that we resolve it.