### PR TITLE
Feature/dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,5 @@
 appveyor.yml
-build.gradle
-config
-gradle
-gradlew
-gradlew.bat
 LICENSE.txt
 README.md
-src
 .git
 .gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+appveyor.yml
+build.gradle
+config
+gradle
+gradlew
+gradlew.bat
+LICENSE.txt
+README.md
+src
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+
+FROM debian:10 as build
+
+ARG release=0.3.0
+
+USER root
+WORKDIR /tmp
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -q -y && apt-get install -y -q \
+      unzip wget
+RUN wget -q -O the_archive.zip "https://github.com/glencoesoftware/raw2ometiff/releases/download/v${release}/raw2ometiff-${release}.zip"
+RUN unzip the_archive.zip
+RUN cd raw2ometiff-* \
+ && mkdir -p /tmp/staging-area \
+ && mv * /tmp/staging-area
+
+
+FROM openjdk:8 as final
+
+USER root
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt-get update -y -q \
+ && apt-get install -y -q libblosc1 \
+ && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=build /tmp/staging-area/ /opt/raw2ometiff/
+ENV PATH="/opt/raw2ometiff/bin:${PATH}"
+
+USER 1000
+WORKDIR /opt/raw2ometiff
+CMD ["raw2ometiff"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ FROM openjdk:8 as final
 USER root
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update -y -q \
- && apt-get install -y -q libblosc1 \
+ && apt-get install -y --no-install-recommends -q libblosc1 \
  && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY --from=build /tmp/staging-area/ /opt/raw2ometiff/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Development Installation
 
     ./gradlew tasks
 
+Docker image
+============
+
+Use the included Docker file to create a Docker image from a release:
+
+     docker build -t whoami/raw2ometiff:0.3.0 - < Dockerfile
+
+
 Eclipse Configuration
 =====================
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Docker image
 
 Use the included Docker file to create a Docker image from a release:
 
-     docker build -t whoami/raw2ometiff:0.3.0 - < Dockerfile
+     docker build -t whoami/raw2ometiff:0.3.0 .
 
 
 Eclipse Configuration


### PR DESCRIPTION
This PR contributes a dockerfile and instructions to build a docker image for raw2ometiff.  Rather than building from source, the dockerfile downloads a pre-compiled release artifact from github.  The version that is downloaded can be specified via an argument, so the dockerfile can easily be re-used for different releases.