### PR TITLE
Document that axes/transformations should be consistent with METADATA.ome.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ By default, LZW compression will be used in the OME-TIFF file.
 The compression can be changed using the `--compression` option.
 Tile compression is performed in parallel.  The number of workers can be changed using the `--max_workers` option.
 
+`axes` and `transformations` metadata in the input Zarr will be ignored. This metadata is assumed to be consistent
+with the corresponding `PhysicalSize*`, `TimeIncrement`, and `DimensionOrder` values in the input `METADATA.ome.xml`.
+
 Areas to improve
 ================
 


### PR DESCRIPTION
Discussed briefly with @joshmoore / @sbesson / @dgault, we don't currently have a strategy for mismatches between Zarr metadata and `METADATA.ome.xml`. Until we figure out a better policy, this at least sets the expectation that only `METADATA.ome.xml` is used here.