### PR TITLE
Clarify that Java 8 is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This is the second half of iSyntax/.mrxs => OME-TIFF conversion.
 Requirements
 ============
 
+Java 8 or later is required.
+
 libblosc (https://github.com/Blosc/c-blosc) version 1.9.0 or later must be installed separately.
 The native libraries are not packaged with any relevant jars.  See also note in jzarr readme (https://github.com/bcdev/jzarr/blob/master/README.md)
 


### PR DESCRIPTION
Java 7 and earlier have never been supported here, since Bio-Formats 6.0.0 switched to requiring Java 8.