### PR TITLE
Fix `--version`

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -212,12 +212,13 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
 
   @Override
   public Void call() throws Exception {
-    // Resolve symlinks
-    inputDirectory = inputDirectory.toRealPath();
     if (printVersion) {
       printVersion();
       return null;
     }
+
+    // Resolve symlinks
+    inputDirectory = inputDirectory.toRealPath();
 
     setupLogger();
 

--- a/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
@@ -458,4 +458,15 @@ public class ConversionTest {
     }
   }
 
+  /**
+   * Test "--version" with no other arguments.
+   * Does not test the version values, just makes sure that an exception
+   * is not thrown.
+   */
+  @Test
+  public void testVersionOnly() throws Exception {
+    CommandLine.call(
+      new PyramidFromDirectoryWriter(), new String[] {"--version"});
+  }
+
 }


### PR DESCRIPTION
@muhanadz noticed that `raw2ometiff --version` throws a `NullPointerException` and does not print the version. This problem was introduced in https://github.com/glencoesoftware/raw2ometiff/pull/65.

With this PR, `raw2ometiff --version` should work again and the test added in 1bae732 should pass. To make sure the test would have caught this problem, check out this PR's branch locally and revert 7e0692c, then run `./gradlew clean build` and make sure `testVersionOnly` fails.