### PR TITLE
Allow OME Zarr group

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -18,6 +18,7 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -508,7 +509,9 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
    * @return number of series
    */
   private int getSeriesCount() throws IOException {
-    int groupKeyCount = reader.getGroupKeys().size();
+    Set<String> groupKeys = reader.getGroupKeys();
+    groupKeys.remove("OME");
+    int groupKeyCount = groupKeys.size();
     LOG.debug("getSeriesCount:");
     LOG.debug("  plateData = {}", plateData);
     LOG.debug("  group key count = {}", groupKeyCount);


### PR DESCRIPTION
See https://github.com/glencoesoftware/bioformats2raw/pull/157

This updates the series finding logic to ignore the `OME` Zarr group, if it exists. Without this change, attempting to convert data generated by https://github.com/glencoesoftware/bioformats2raw/pull/157 resulted in something like:

```
Exception in thread "main" picocli.CommandLine$ExecutionException: Error while calling command (com.glencoesoftware.pyramid.PyramidFromDirectoryWriter@635eaaf1): java.lang.RuntimeException: java.io.IOException: Path '/home/melissa/test-series/10' is not a valid path or not a directory.
	at picocli.CommandLine.executeUserObject(CommandLine.java:1792)
	at picocli.CommandLine.access$900(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2150)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2144)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2108)
	at picocli.CommandLine$AbstractParseResultHandler.handleParseResult(CommandLine.java:1968)
	at picocli.CommandLine.parseWithHandlers(CommandLine.java:2349)
	at picocli.CommandLine.parseWithHandler(CommandLine.java:2284)
	at picocli.CommandLine.call(CommandLine.java:2560)
	at com.glencoesoftware.pyramid.PyramidFromDirectoryWriter.main(PyramidFromDirectoryWriter.java:210)
Caused by: java.lang.RuntimeException: java.io.IOException: Path '/home/melissa/test-series/10' is not a valid path or not a directory.
	at com.glencoesoftware.pyramid.PyramidFromDirectoryWriter.call(PyramidFromDirectoryWriter.java:242)
	at com.glencoesoftware.pyramid.PyramidFromDirectoryWriter.call(PyramidFromDirectoryWriter.java:97)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1783)
	... 9 more
Caused by: java.io.IOException: Path '/home/melissa/test-series/10' is not a valid path or not a directory.
	at com.bc.zarr.ZarrUtils.ensureDirectory(ZarrUtils.java:159)
	at com.bc.zarr.ZarrGroup.open(ZarrGroup.java:94)
	at com.bc.zarr.ZarrGroup.open(ZarrGroup.java:87)
	at com.glencoesoftware.pyramid.PyramidFromDirectoryWriter.getZarrGroup(PyramidFromDirectoryWriter.java:498)
	at com.glencoesoftware.pyramid.PyramidFromDirectoryWriter.findNumberOfResolutions(PyramidFromDirectoryWriter.java:552)
	at com.glencoesoftware.pyramid.PyramidFromDirectoryWriter.initialize(PyramidFromDirectoryWriter.java:649)
	at com.glencoesoftware.pyramid.PyramidFromDirectoryWriter.call(PyramidFromDirectoryWriter.java:228)
	... 11 more
```

Since raw2ometiff converts all series anyway, I haven't changed this to read the `series` list from the `OME` group attributes.

This should continue to work with Zarr data that doesn't have an `OME` group at all.