### PR TITLE
Preserve OMERO rendering metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ Tile compression is performed in parallel.  The number of workers can be changed
 `axes` and `transformations` metadata in the input Zarr will be ignored. This metadata is assumed to be consistent
 with the corresponding `PhysicalSize*`, `TimeIncrement`, and `DimensionOrder` values in the input `METADATA.ome.xml`.
 
+For non-plate data, a `MapAnnotation` with namespace `glencoesoftware.com/ngff/rendering` will be linked to each `Channel` in the OME-XML.
+This `MapAnnotation` records the minimum (key `min`) and maximum (key `max`) pixel values for the channel.
+This information is taken from the `min` and `max` values under `omero` in the input Zarr dataset, as described in https://ngff.openmicroscopy.org/latest/#omero-md.
+If `omero` metadata was not recorded in the input Zarr dataset, annotations will be omitted.
+For plate data, annotations will only be written if the `--force-channel-annotations` option is used. Linking an annotation to every `Channel` in
+a plate is known to cause performance issues when importing the resulting file into OMERO.
+See the discussion around https://github.com/glencoesoftware/raw2ometiff/pull/82#pullrequestreview-1179070542
+
 Areas to improve
 ================
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,9 @@ repositories {
         url 'https://artifacts.glencoesoftware.com/artifactory/ome.releases/'
     }
     maven {
+        url 'https://artifacts.glencoesoftware.com/artifactory/unidata-releases/'
+    }
+    maven {
         url 'https://repo.glencoesoftware.com/repository/bioformats2raw2ometiff/'
     }
     maven {

--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -733,7 +733,6 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
       totalPlanes += s.planeCount;
 
       // capture the OMERO rendering metadata in a few different annotations
-      // TODO: pick just one
 
       ZarrGroup z = getZarrGroup(s.path);
       Map<String, Object> attrs =
@@ -742,9 +741,6 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
         // one MapAnnotation with two key/value pairs (min, max)
         // linked to each channel
         setChannelMinMaxMapAnnotation(attrs, seriesIndex);
-
-        // two DoubleAnnotations (one min, one max) linked to each channel
-        setChannelMinMaxAnnotations(attrs, seriesIndex);
       }
     }
 
@@ -1300,53 +1296,6 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
       metadata.setMapAnnotationValue(renderingMap, mapIndex);
       metadata.setChannelAnnotationRef(annotationID, seriesIndex, c,
         metadata.getChannelAnnotationRefCount(seriesIndex, c));
-    }
-  }
-
-  private void setChannelMinMaxAnnotations(
-    Map<String, Object> attrs, int seriesIndex)
-  {
-    if (!attrs.containsKey("channels")) {
-      return;
-    }
-    List<Map<String, Object>> channels =
-      (List<Map<String, Object>>) attrs.get("channels");
-
-    int doubleIndex = 0;
-    try {
-      doubleIndex = metadata.getDoubleAnnotationCount();
-    }
-    catch (NullPointerException e) {
-      // expected when no annotations are present yet
-    }
-
-    for (int c=0; c<channels.size(); c++) {
-      Map<String, Object> channel = channels.get(c);
-      Map<String, Object> window = (Map<String, Object>) channel.get("window");
-      Double min = (Double) window.get("min");
-      Double max = (Double) window.get("max");
-
-      String minAnnotationID = getNextAnnotationID(seriesIndex, c);
-      metadata.setDoubleAnnotationID(minAnnotationID, doubleIndex);
-      metadata.setDoubleAnnotationNamespace(
-        "glencoesoftware.com/ngff/rendering/min", doubleIndex);
-      metadata.setDoubleAnnotationDescription("channel min", doubleIndex);
-      metadata.setDoubleAnnotationValue(min, doubleIndex);
-      metadata.setChannelAnnotationRef(minAnnotationID, seriesIndex, c,
-        metadata.getChannelAnnotationRefCount(seriesIndex, c));
-
-      doubleIndex++;
-
-      String maxAnnotationID = getNextAnnotationID(seriesIndex, c);
-      metadata.setDoubleAnnotationID(maxAnnotationID, doubleIndex);
-      metadata.setDoubleAnnotationNamespace(
-        "glencoesoftware.com/ngff/rendering/max", doubleIndex);
-      metadata.setDoubleAnnotationDescription("channel max", doubleIndex);
-      metadata.setDoubleAnnotationValue(max, doubleIndex);
-      metadata.setChannelAnnotationRef(maxAnnotationID, seriesIndex, c,
-        metadata.getChannelAnnotationRefCount(seriesIndex, c));
-
-      doubleIndex++;
     }
   }
 

--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -38,7 +38,6 @@ import loci.common.Region;
 import loci.common.services.DependencyException;
 import loci.common.services.ServiceException;
 import loci.common.services.ServiceFactory;
-import loci.common.xml.XMLTools;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
@@ -70,10 +69,8 @@ import org.perf4j.StopWatch;
 import org.perf4j.slf4j.Slf4JStopWatch;
 
 import com.bc.zarr.DataType;
-import com.bc.zarr.JZarrException;
 import com.bc.zarr.ZarrArray;
 import com.bc.zarr.ZarrGroup;
-import com.bc.zarr.ZarrUtils;
 import ucar.ma2.InvalidRangeException;
 
 import picocli.CommandLine;
@@ -737,33 +734,17 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
 
       // capture the OMERO rendering metadata in a few different annotations
       // TODO: pick just one
-      try {
-        ZarrGroup z = getZarrGroup(s.path);
-        Map<String, Object> attrs =
-          (Map<String, Object>) z.getAttributes().get("omero");
-        if (attrs != null) {
-          // one MapAnnotation with one key/value pair
-          // where the value is the raw JSON
-          setSimpleMapAnnotation(attrs, seriesIndex);
 
-          // one MapAnnotation, one key/value pair per channel
-          // the key is the channel index, the value is a string representing
-          // two doubles separated by a single space
-          setMinMaxMapAnnotation(attrs, seriesIndex);
+      ZarrGroup z = getZarrGroup(s.path);
+      Map<String, Object> attrs =
+        (Map<String, Object>) z.getAttributes().get("omero");
+      if (attrs != null) {
+        // one MapAnnotation with two key/value pairs (min, max)
+        // linked to each channel
+        setChannelMinMaxMapAnnotation(attrs, seriesIndex);
 
-          // two DoubleAnnotations (one min, one max) linked to each channel
-          setChannelMinMaxAnnotations(attrs, seriesIndex);
-
-          // one each of the remaining annotations which hold a single string
-          // the value is the raw JSON
-          setSimpleXMLAnnotation(attrs, seriesIndex);
-          setSimpleCommentAnnotation(attrs, seriesIndex);
-          setSimpleTagAnnotation(attrs, seriesIndex);
-          setSimpleTermAnnotation(attrs, seriesIndex);
-        }
-      }
-      catch (JZarrException e) {
-        throw new FormatException("Could not get attributes for " + s.path, e);
+        // two DoubleAnnotations (one min, one max) linked to each channel
+        setChannelMinMaxAnnotations(attrs, seriesIndex);
       }
     }
 
@@ -1282,17 +1263,14 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
     return attr.toString();
   }
 
-  private void setSimpleMapAnnotation(
+  private void setChannelMinMaxMapAnnotation(
     Map<String, Object> attrs, int seriesIndex)
-    throws JZarrException
   {
-    // if OMERO rendering metadata is present in the Zarr attributes,
-    // copy it to a MapAnnotation
-    // this allows min/max values to be preserved and used by other tools
-    // that recognize the annotation
-    List<MapPair> renderingMap = new ArrayList<MapPair>();
-    String omeroJSON = ZarrUtils.toJson(attrs);
-    renderingMap.add(new MapPair("omero", omeroJSON));
+    if (!attrs.containsKey("channels")) {
+      return;
+    }
+    List<Map<String, Object>> channels =
+      (List<Map<String, Object>>) attrs.get("channels");
 
     int mapIndex = 0;
     try {
@@ -1302,155 +1280,27 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
       // expected when no annotations are present yet
     }
 
-    // annotation ID and indexes are set to minimize the chance of
-    // clashing with an existing annotation
-    String annotationID = getNextAnnotationID(seriesIndex);
-    metadata.setMapAnnotationID(annotationID, mapIndex);
-    metadata.setMapAnnotationNamespace(
-      "glencoesoftware.com/ngff/rendering", mapIndex);
-    metadata.setMapAnnotationValue(renderingMap, mapIndex);
-    metadata.setImageAnnotationRef(annotationID, seriesIndex,
-      metadata.getImageAnnotationRefCount(seriesIndex));
-  }
-
-  private void setMinMaxMapAnnotation(
-    Map<String, Object> attrs, int seriesIndex)
-  {
-    if (!attrs.containsKey("channels")) {
-      return;
-    }
-    List<MapPair> renderingMap = new ArrayList<MapPair>();
-    List<Map<String, Object>> channels =
-      (List<Map<String, Object>>) attrs.get("channels");
-
-    for (int c=0; c<channels.size(); c++) {
+    for (int c=0; c<channels.size(); c++, mapIndex++) {
+      List<MapPair> renderingMap = new ArrayList<MapPair>();
       Map<String, Object> channel = channels.get(c);
       Map<String, Object> window = (Map<String, Object>) channel.get("window");
       Double min = (Double) window.get("min");
       Double max = (Double) window.get("max");
 
       // MapPair only allows string values
-      renderingMap.add(new MapPair(String.valueOf(c), min + " " + max));
+      renderingMap.add(new MapPair("min", min.toString()));
+      renderingMap.add(new MapPair("max", max.toString()));
+
+      // annotation ID and indexes are set to minimize the chance of
+      // clashing with an existing annotation
+      String annotationID = getNextAnnotationID(seriesIndex, c);
+      metadata.setMapAnnotationID(annotationID, mapIndex);
+      metadata.setMapAnnotationNamespace(
+        "glencoesoftware.com/ngff/rendering", mapIndex);
+      metadata.setMapAnnotationValue(renderingMap, mapIndex);
+      metadata.setChannelAnnotationRef(annotationID, seriesIndex, c,
+        metadata.getChannelAnnotationRefCount(seriesIndex, c));
     }
-
-    int mapIndex = 0;
-    try {
-      mapIndex = metadata.getMapAnnotationCount();
-    }
-    catch (NullPointerException e) {
-      // expected when no annotations are present yet
-    }
-
-    // annotation ID and indexes are set to minimize the chance of
-    // clashing with an existing annotation
-    String annotationID = getNextAnnotationID(seriesIndex);
-    metadata.setMapAnnotationID(annotationID, mapIndex);
-    metadata.setMapAnnotationNamespace(
-      "glencoesoftware.com/ngff/rendering", mapIndex);
-    metadata.setMapAnnotationValue(renderingMap, mapIndex);
-    metadata.setImageAnnotationRef(annotationID, seriesIndex,
-      metadata.getImageAnnotationRefCount(seriesIndex));
-  }
-
-  private void setSimpleXMLAnnotation(
-    Map<String, Object> attrs, int seriesIndex)
-    throws JZarrException
-  {
-    String omeroJSON = ZarrUtils.toJson(attrs);
-    omeroJSON = XMLTools.escapeXML(omeroJSON);
-
-    int xmlIndex = 0;
-    try {
-      xmlIndex = metadata.getXMLAnnotationCount();
-    }
-    catch (NullPointerException e) {
-      // expected when no annotations are present yet
-    }
-
-    // annotation ID and indexes are set to minimize the chance of
-    // clashing with an existing annotation
-    String annotationID = getNextAnnotationID(seriesIndex);
-    metadata.setXMLAnnotationID(annotationID, xmlIndex);
-    metadata.setXMLAnnotationNamespace(
-      "glencoesoftware.com/ngff/rendering", xmlIndex);
-    metadata.setXMLAnnotationValue(omeroJSON, xmlIndex);
-    metadata.setImageAnnotationRef(annotationID, seriesIndex,
-      metadata.getImageAnnotationRefCount(seriesIndex));
-  }
-
-  private void setSimpleCommentAnnotation(
-    Map<String, Object> attrs, int seriesIndex)
-    throws JZarrException
-  {
-    String omeroJSON = ZarrUtils.toJson(attrs);
-
-    int commentIndex = 0;
-    try {
-      commentIndex = metadata.getCommentAnnotationCount();
-    }
-    catch (NullPointerException e) {
-      // expected when no annotations are present yet
-    }
-
-    // annotation ID and indexes are set to minimize the chance of
-    // clashing with an existing annotation
-    String annotationID = getNextAnnotationID(seriesIndex);
-    metadata.setCommentAnnotationID(annotationID, commentIndex);
-    metadata.setCommentAnnotationNamespace(
-      "glencoesoftware.com/ngff/rendering", commentIndex);
-    metadata.setCommentAnnotationValue(omeroJSON, commentIndex);
-    metadata.setImageAnnotationRef(annotationID, seriesIndex,
-      metadata.getImageAnnotationRefCount(seriesIndex));
-  }
-
-  private void setSimpleTagAnnotation(
-    Map<String, Object> attrs, int seriesIndex)
-    throws JZarrException
-  {
-    String omeroJSON = ZarrUtils.toJson(attrs);
-
-    int tagIndex = 0;
-    try {
-      tagIndex = metadata.getTagAnnotationCount();
-    }
-    catch (NullPointerException e) {
-      // expected when no annotations are present yet
-    }
-
-    // annotation ID and indexes are set to minimize the chance of
-    // clashing with an existing annotation
-    String annotationID = getNextAnnotationID(seriesIndex);
-    metadata.setTagAnnotationID(annotationID, tagIndex);
-    metadata.setTagAnnotationNamespace(
-      "glencoesoftware.com/ngff/rendering", tagIndex);
-    metadata.setTagAnnotationValue(omeroJSON, tagIndex);
-    metadata.setImageAnnotationRef(annotationID, seriesIndex,
-      metadata.getImageAnnotationRefCount(seriesIndex));
-  }
-
-  private void setSimpleTermAnnotation(
-    Map<String, Object> attrs, int seriesIndex)
-    throws JZarrException
-  {
-    String omeroJSON = ZarrUtils.toJson(attrs);
-
-    int termIndex = 0;
-    try {
-      termIndex = metadata.getTermAnnotationCount();
-    }
-    catch (NullPointerException e) {
-      // expected when no annotations are present yet
-    }
-
-    // annotation ID and indexes are set to minimize the chance of
-    // clashing with an existing annotation
-    String annotationID = getNextAnnotationID(seriesIndex);
-    metadata.setTermAnnotationID(annotationID, termIndex);
-    metadata.setTermAnnotationNamespace(
-      "glencoesoftware.com/ngff/rendering", termIndex);
-    metadata.setTermAnnotationValue(omeroJSON, termIndex);
-    metadata.setImageAnnotationRef(annotationID, seriesIndex,
-      metadata.getImageAnnotationRefCount(seriesIndex));
   }
 
   private void setChannelMinMaxAnnotations(
@@ -1476,11 +1326,10 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
       Double min = (Double) window.get("min");
       Double max = (Double) window.get("max");
 
-      String minAnnotationID =
-        "Annotation:Rendering:Channel:" + seriesIndex + ":" + (c * 2);
+      String minAnnotationID = getNextAnnotationID(seriesIndex, c);
       metadata.setDoubleAnnotationID(minAnnotationID, doubleIndex);
       metadata.setDoubleAnnotationNamespace(
-        "glencoesoftware.com/ngff/rendering", doubleIndex);
+        "glencoesoftware.com/ngff/rendering/min", doubleIndex);
       metadata.setDoubleAnnotationDescription("channel min", doubleIndex);
       metadata.setDoubleAnnotationValue(min, doubleIndex);
       metadata.setChannelAnnotationRef(minAnnotationID, seriesIndex, c,
@@ -1488,11 +1337,10 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
 
       doubleIndex++;
 
-      String maxAnnotationID =
-        "Annotation:Rendering:Channel:" + seriesIndex + ":" + ((c * 2) + 1);
+      String maxAnnotationID = getNextAnnotationID(seriesIndex, c);
       metadata.setDoubleAnnotationID(maxAnnotationID, doubleIndex);
       metadata.setDoubleAnnotationNamespace(
-        "glencoesoftware.com/ngff/rendering", doubleIndex);
+        "glencoesoftware.com/ngff/rendering/max", doubleIndex);
       metadata.setDoubleAnnotationDescription("channel max", doubleIndex);
       metadata.setDoubleAnnotationValue(max, doubleIndex);
       metadata.setChannelAnnotationRef(maxAnnotationID, seriesIndex, c,
@@ -1502,15 +1350,16 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
     }
   }
 
-  private String getNextAnnotationID(int seriesIndex) {
-    String base = "Annotation:Rendering:" + seriesIndex + ":";
+  private String getNextAnnotationID(int seriesIndex, int channel) {
+    String base = "Annotation:Rendering:" + seriesIndex + ":" + channel + ":";
     int start = 0;
 
     metadata.resolveReferences();
     OMEXMLMetadataRoot root = (OMEXMLMetadataRoot) metadata.getRoot();
     Image img = root.getImage(seriesIndex);
-    for (int a=0; a<img.sizeOfLinkedAnnotationList(); a++) {
-      String annotationID = img.getLinkedAnnotation(a).getID();
+    Channel ch = img.getPixels().getChannel(channel);
+    for (int a=0; a<ch.sizeOfLinkedAnnotationList(); a++) {
+      String annotationID = ch.getLinkedAnnotation(a).getID();
       if (annotationID.equals(base + start)) {
         start++;
       }

--- a/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
@@ -440,6 +440,45 @@ public class ConversionTest {
       Assert.assertEquals(24, reader.getSeriesCount());
       Assert.assertEquals(24, metadata.getImageCount());
       Assert.assertEquals(1, metadata.getPlateCount());
+
+      for (int series=0; series<metadata.getImageCount(); series++) {
+        int channelCount = metadata.getChannelCount(series);
+        for (int channel=0; channel<channelCount; channel++) {
+          int refCount = metadata.getChannelAnnotationRefCount(series, channel);
+          Assert.assertEquals(0, refCount);
+        }
+      }
+    }
+  }
+
+  /**
+   * Test larger plate with min/max annotations.
+   */
+  @Test
+  public void testPlateWithAnnotations() throws Exception {
+    input =
+      fake("plateRows", "8", "plateCols", "12", "fields", "4", "sizeC", "4");
+    assertBioFormats2Raw();
+    assertTool("--force-channel-annotations");
+    iteratePixels();
+    try (ImageReader reader = new ImageReader()) {
+      ServiceFactory sf = new ServiceFactory();
+      OMEXMLService xmlService = sf.getInstance(OMEXMLService.class);
+      OMEXMLMetadata metadata = xmlService.createOMEXMLMetadata();
+      reader.setMetadataStore(metadata);
+      reader.setFlattenedResolutions(false);
+      reader.setId(outputOmeTiff.toString());
+      Assert.assertEquals(384, reader.getSeriesCount());
+      Assert.assertEquals(384, metadata.getImageCount());
+      Assert.assertEquals(1, metadata.getPlateCount());
+
+      for (int series=0; series<metadata.getImageCount(); series++) {
+        int channelCount = metadata.getChannelCount(series);
+        for (int channel=0; channel<channelCount; channel++) {
+          int refCount = metadata.getChannelAnnotationRefCount(series, channel);
+          Assert.assertEquals(1, refCount);
+        }
+      }
     }
   }
 
@@ -462,6 +501,14 @@ public class ConversionTest {
       Assert.assertEquals(1, reader.getSeriesCount());
       Assert.assertEquals(1, metadata.getImageCount());
       Assert.assertEquals(0, metadata.getPlateCount());
+
+      for (int series=0; series<metadata.getImageCount(); series++) {
+        int channelCount = metadata.getChannelCount(series);
+        for (int channel=0; channel<channelCount; channel++) {
+          int refCount = metadata.getChannelAnnotationRefCount(series, channel);
+          Assert.assertEquals(1, refCount);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
See https://github.com/glencoesoftware/bioformats2raw/pull/160

Discussed with @mgheirat, @muhanadz, and @sbesson that it would be nice to keep any calculated min/max values when converting to OME-TIFF. Since there isn't really a place in the OME schema to do that, this PR uses a `MapAnnotation` linked to each `Image`. The `MapAnnotation` has the namespace `glencoesoftware.com/ngff/rendering`, and a single key (`omero`) whose value is the JSON described here: https://ngff.openmicroscopy.org/latest/#omero-md.

Namespace, annotation type, etc. all up for debate if anyone has better ideas. Not necessarily expecting this to be merged as-is, it's just a place to start. I thought about using an `XMLAnnotation` instead, like we do for the JSON annotation described here: https://github.com/glencoesoftware/ome-omero-roitool/blob/master/src/main/java/com/glencoesoftware/roitool/OMEOMEROConverter.java#L199. `MapAnnotation` seemed less likely to break things that might try to parse an `XMLAnnotation` value.

It should be possible to convert an input dataset to OME-TIFF with https://github.com/glencoesoftware/bioformats2raw/pull/160 and this PR, and see the linked annotations with `showinf -nopix -noflat -omexml` on the output OME-TIFF. Importing the OME-TIFF to OMERO should allow the annotations to be queried - get the `Image` first, then look for linked annotations with the `glencoesoftware.com/ngff/rendering` namespace.

No tests (yet) because we'd need a released version of bioformats2raw that generates OMERO metadata. 