### PR TITLE
Use HTTPS URL for senbox Nexus repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
         url 'https://repo.glencoesoftware.com/repository/bioformats2raw2ometiff/'
     }
     maven {
-        url 'http://nexus.senbox.net/nexus/content/groups/public'
+        url 'https://nexus.senbox.net/nexus/content/groups/public'
     }
     maven {
         url 'https://repo.glencoesoftware.com/repository/jzarr-snapshots'


### PR DESCRIPTION
Compilation using Gradle 7.4.2/Java 11 failed locally with error of type "Using insecure protocols with repositories, without explicit opt-in, is unsupported."