### PR TITLE
Logback 1.3.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation 'ome:formats-bsd:6.4.0'
     // be careful here, this is a newer version of org.json:json than formats-gpl uses
     implementation 'org.json:json:20190722'
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.4'
+    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.3.4'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.apache.commons:commons-lang3:3.12.0'
     testImplementation 'com.glencoesoftware:bioformats2raw:0.3.0'


### PR DESCRIPTION
See also https://github.com/glencoesoftware/bioformats2raw/pull/167

Set the version to 1.3.4 which is the latest release of the stable version supporting JDK 8