### PR TITLE
Force tile sizes to be a multiple of 16

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidSeries.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidSeries.java
@@ -76,6 +76,18 @@ public class PyramidSeries {
       descriptor.sizeY = dimensions[dimensions.length - 2];
       descriptor.tileSizeX = blockSizes[blockSizes.length - 1];
       descriptor.tileSizeY = blockSizes[blockSizes.length - 2];
+
+      if (descriptor.tileSizeX % 16 != 0) {
+        LOG.warn("Tile width ({}) not a multiple of 16; correcting",
+          descriptor.tileSizeX);
+        descriptor.tileSizeX += (16 - (descriptor.tileSizeX % 16));
+      }
+      if (descriptor.tileSizeY % 16 != 0) {
+        LOG.warn("Tile height ({}) not a multiple of 16; correcting",
+          descriptor.tileSizeY);
+        descriptor.tileSizeY += (16 - (descriptor.tileSizeY % 16));
+      }
+
       descriptor.numberOfTilesX =
         getTileCount(descriptor.sizeX, descriptor.tileSizeX);
       descriptor.numberOfTilesY =

--- a/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
@@ -383,8 +383,19 @@ public class ConversionTest {
   public void testOddTileSize() throws Exception {
     input = fake("pixelType", "uint16");
     assertBioFormats2Raw("-w", "17", "-h", "19");
-    assertTool();
+    assertTool("--compression", "raw");
     iteratePixels();
+
+    try (TiffParser parser = new TiffParser(outputOmeTiff.toString())) {
+      IFDList mainIFDs = parser.getMainIFDs();
+      Assert.assertEquals(1, mainIFDs.size());
+      int tileSize = 32 * 32 * 2;
+      long[] tileByteCounts = mainIFDs.get(0).getStripByteCounts();
+      Assert.assertEquals(256, tileByteCounts.length);
+      for (long count : tileByteCounts) {
+        Assert.assertEquals(tileSize, count);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #88.

Tile sizes were previously taken directly from the input zarr's chunk sizes. Now, if the chunk size is a multiple of 16 it will be used directly, otherwise it will be rounded up to the next multiple of 16. This mostly affects the smallest resolution images (which are typically a single tile) and datasets generated by bioformats2raw with non-default tile sizes. When the tile size is calculated to be different from the chunk size, a warning is now printed.

This shouldn't actually affect pixel data that is returned when reading converted OME-TIFFs (with Bio-Formats, at least). It should eliminate warnings from libtiff as described in the test case in #88.