### PR TITLE
Expand support for `--rgb`

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -679,7 +679,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
       s.dimensionLengths[s.dimensionOrder.indexOf("T") - 2] = s.t;
       s.dimensionLengths[s.dimensionOrder.indexOf("C") - 2] = s.c;
 
-      s.rgb = rgb && (s.c == 3) && (s.z * s.t == 1);
+      s.rgb = rgb && (s.c == 3);
       if (!s.rgb) {
         s.planeCount *= s.c;
       }

--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -861,7 +861,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
                     StopWatch t0 = new Slf4JStopWatch("getInputTileBytes");
                     byte[] tileBytes;
                     try {
-                      // assumes TCZXY order consistent with OME-NGFF spec
+                      // assumes TCZYX order consistent with bioformats2raw
                       int planeIndex = FormatTools.positionToRaster(
                         s.dimensionLengths,
                         new int[] {z, c * rgbChannels + ch, t});

--- a/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
@@ -210,6 +210,9 @@ public class ConversionTest {
           inputReader.setSeries(series);
           outputReader.setSeries(series);
 
+          Assert.assertEquals(
+            inputReader.getImageCount(), outputReader.getImageCount());
+          Assert.assertEquals(inputReader.getSizeC(), outputReader.getSizeC());
           for (int plane=0; plane<inputReader.getImageCount(); plane++) {
             Object inputPlane = getPlane(inputReader, plane);
             Object outputPlane = getPlane(outputReader, plane);
@@ -395,6 +398,28 @@ public class ConversionTest {
     input = fake("sizeX", "497", "sizeY", "498", "pixelType", "uint16");
     assertBioFormats2Raw("-w", "128", "-h", "128");
     assertTool();
+    iteratePixels();
+  }
+
+  /**
+   * Test RGB with multiple timepoints.
+   */
+  @Test
+  public void testRGBMultiT() throws Exception {
+    input = fake("sizeC", "3", "sizeT", "5", "rgb", "3");
+    assertBioFormats2Raw();
+    assertTool("--rgb");
+    iteratePixels();
+  }
+
+  /**
+   * Test RGB with multiple channels.
+   */
+  @Test
+  public void testRGBMultiC() throws Exception {
+    input = fake("sizeC", "12", "rgb", "3");
+    assertBioFormats2Raw();
+    assertTool("--rgb");
     iteratePixels();
   }
 


### PR DESCRIPTION
Attempts to address #43, as discussed briefly with @sbesson. This still requires that the input channel count be a multiple of 3, as channel merging happens in groups of 3. As noted in the comments, this is maybe something we could consider making configurable as a next step.

More than one timepoint and/or Z section should be supported, along with channel counts greater than 3 (but still a multiple of 3). I tested with 12 channel Zeiss ZVI data (`curated/zeiss-zvi/cecilia/*.zvi`) and various RGB Z stacks/timelapse movies (e.g. some of `curated/apng/samples/`, `curated/zeiss-czi/qa-17173`).