### PR TITLE
Bump formats-bsd to version 6.11.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation 'com.bc.zarr:jzarr:0.3.5'
     implementation 'info.picocli:picocli:4.2.0'
     implementation 'me.tongfei:progressbar:0.9.0'
-    implementation 'ome:formats-bsd:6.11.0'
+    implementation 'ome:formats-bsd:6.11.1'
     // be careful here, this is a newer version of org.json:json than formats-gpl uses
     implementation 'org.json:json:20190722'
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.4'


### PR DESCRIPTION
Tracks the latest release of OME Bio-Formats in preparation of the upcoming set of conversion utility releases.

Companion to https://github.com/glencoesoftware/bioformats2raw/pull/178