### PR TITLE
Use new bioformats2raw progress API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,13 +41,13 @@ dependencies {
     implementation 'info.picocli:picocli:4.2.0'
     implementation 'me.tongfei:progressbar:0.9.0'
     implementation 'ome:formats-bsd:6.11.1'
+    implementation 'com.glencoesoftware:bioformats2raw:0.7.0'
     // be careful here, this is a newer version of org.json:json than formats-gpl uses
     implementation 'org.json:json:20190722'
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.4'
     implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.3.4'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.apache.commons:commons-lang3:3.12.0'
-    testImplementation 'com.glencoesoftware:bioformats2raw:0.5.0'
 }
 
 test {

--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -26,9 +26,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import ch.qos.logback.classic.Level;
-import me.tongfei.progressbar.DelegatingProgressBarConsumer;
-import me.tongfei.progressbar.ProgressBar;
-import me.tongfei.progressbar.ProgressBarBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,6 +66,9 @@ import org.perf4j.slf4j.Slf4JStopWatch;
 import com.bc.zarr.DataType;
 import com.bc.zarr.ZarrArray;
 import com.bc.zarr.ZarrGroup;
+import com.glencoesoftware.bioformats2raw.IProgressListener;
+import com.glencoesoftware.bioformats2raw.NoOpProgressListener;
+import com.glencoesoftware.bioformats2raw.ProgressBarListener;
 import ucar.ma2.InvalidRangeException;
 
 import picocli.CommandLine;
@@ -114,6 +114,8 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
 
   private BlockingQueue<Runnable> tileQueue;
   private ExecutorService executor;
+
+  private IProgressListener progressListener;
 
   /** Where to write? */
   @Parameters(
@@ -212,11 +214,38 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
     CommandLine.call(new PyramidFromDirectoryWriter(), args);
   }
 
+  /**
+   * Set a listener for tile processing events.
+   * Intended to be used to show a status bar.
+   *
+   * @param listener a progress event listener
+   */
+  public void setProgressListener(IProgressListener listener) {
+    progressListener = listener;
+  }
+
+  /**
+   * Get the current listener for tile processing events.
+   * If no listener was set, a no-op listener is returned.
+   *
+   * @return the current progress listener
+   */
+  public IProgressListener getProgressListener() {
+    if (progressListener == null) {
+      setProgressListener(new NoOpProgressListener());
+    }
+    return progressListener;
+  }
+
   @Override
   public Void call() throws Exception {
     if (printVersion) {
       printVersion();
       return null;
+    }
+
+    if (progressBars) {
+      setProgressListener(new ProgressBarListener(logLevel));
     }
 
     // Resolve symlinks
@@ -291,6 +320,8 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
       int no, int x, int y, Region region)
       throws FormatException, IOException
   {
+    int[] pos = FormatTools.rasterToPosition(s.dimensionLengths, no);
+    getProgressListener().notifyChunkStart(plane, x, y, pos[0]);
     ResolutionDescriptor descriptor = s.resolutions.get(resolution);
     int realWidth = descriptor.tileSizeX;
     int realHeight = descriptor.tileSizeY;
@@ -299,7 +330,6 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
       realHeight = region.height;
     }
 
-    int[] pos = FormatTools.rasterToPosition(s.dimensionLengths, no);
     int[] gridPosition = new int[] {pos[2], pos[1], pos[0],
       y * descriptor.tileSizeY, x * descriptor.tileSizeX};
     int[] shape = new int[] {1, 1, 1, realHeight, realWidth};
@@ -799,6 +829,8 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
     throws FormatException, IOException,
       InterruptedException, DependencyException
   {
+    getProgressListener().notifySeriesStart(s.index);
+
     // convert every resolution in the pyramid
     s.ifds = new IFDList[s.numberOfResolutions];
     for (int resolution=0; resolution<s.numberOfResolutions; resolution++) {
@@ -817,24 +849,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
         ResolutionDescriptor descriptor = s.resolutions.get(resolution);
         int tileCount = descriptor.numberOfTilesY * descriptor.numberOfTilesX;
 
-        final ProgressBar pb;
-        if (progressBars) {
-          ProgressBarBuilder builder = new ProgressBarBuilder()
-            .setInitialMax(tileCount * s.planeCount)
-            .setTaskName(String.format("[%d/%d]", s.index, resolution));
-
-          if (!(logLevel.equals("OFF") ||
-            logLevel.equals("ERROR") ||
-            logLevel.equals("WARN")))
-          {
-            builder.setConsumer(new DelegatingProgressBarConsumer(LOG::trace));
-          }
-
-          pb = builder.build();
-        }
-        else {
-          pb = null;
-        }
+        getProgressListener().notifyResolutionStart(resolution, tileCount);
 
         int plane = 0;
         for (int t=0; t<s.t; t++) {
@@ -884,7 +899,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
                             region.height == descriptor.tileSizeY)
                           {
                             writeTile(s, currentPlane, tileBytes,
-                              currentIndex, currentResolution);
+                              currentIndex, currentResolution, x, y, z);
                           }
                           else {
                             // padded tile, use descriptor X and Y tile size
@@ -900,7 +915,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
                                 realTile, row * outRowLen, inRowLen);
                             }
                             writeTile(s, currentPlane, realTile,
-                              currentIndex, currentResolution);
+                              currentIndex, currentResolution, x, y, z);
                           }
                         }
                       }
@@ -911,9 +926,6 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
                       }
                       finally {
                         t1.stop();
-                        if (pb != null) {
-                          pb.step();
-                        }
                       }
                     });
                   }
@@ -923,15 +935,13 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
           }
         }
 
-        if (pb != null) {
-          pb.close();
-        }
-
+        getProgressListener().notifyResolutionEnd(resolution);
       }
     }
     finally {
       executor.shutdown();
       executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+      getProgressListener().notifySeriesEnd(s.index);
     }
   }
 
@@ -1108,9 +1118,13 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
    * @param buffer the array containing the tile's pixel data
    * @param tileIndex index of the tile to be written in XY space
    * @param resolution resolution index of the tile
+   * @param x tile index along X
+   * @param y tile index along Y
+   * @param z Z index corresponding to imageNumber
    */
   private void writeTile(PyramidSeries s,
-      Integer imageNumber, byte[] buffer, int tileIndex, int resolution)
+      Integer imageNumber, byte[] buffer, int tileIndex, int resolution,
+      int x, int y, int z)
       throws FormatException, IOException
   {
     LOG.debug("Writing series: {}, image: {}, tileIndex: {}",
@@ -1137,6 +1151,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
       realTile.length, outStream.getFilePointer());
 
     writeToDisk(s, realTile, tileIndex, resolution, imageNumber);
+    getProgressListener().notifyChunkEnd(imageNumber, x, y, z);
   }
 
   /**


### PR DESCRIPTION
This won't compile, it's just a place to start. See https://github.com/glencoesoftware/bioformats2raw/pull/172.

Probably main point is whether a hard dependency on bioformats2raw is what we want. If not, that would mean either reimplementing listeners here or putting listeners somewhere else that both bioformats2raw and raw2ometiff can use.