### PR TITLE
RGB & color handling

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -55,6 +55,7 @@ import ome.units.UNITS;
 import ome.units.quantity.Length;
 import ome.xml.meta.OMEXMLMetadataRoot;
 import ome.xml.model.Channel;
+import ome.xml.model.FilterSet;
 import ome.xml.model.Pixels;
 import ome.xml.model.enums.DimensionOrder;
 import ome.xml.model.enums.EnumerationException;
@@ -707,7 +708,35 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
         for (int index=0; index<pixels.sizeOfChannelList(); index++) {
           Channel channel = pixels.getChannel(index);
           channel.setSamplesPerPixel(new PositiveInteger(rgbChannels));
-          channel.setColor(null);
+          if (channel.getColor() != null) {
+            LOG.warn("Removing channel color");
+            channel.setColor(null);
+          }
+          if (channel.getEmissionWavelength() != null) {
+            LOG.warn("Removing channel emission wavelength");
+            channel.setEmissionWavelength(null);
+          }
+          if (channel.getExcitationWavelength() != null) {
+            LOG.warn("Removing channel excitation wavelength");
+            channel.setEmissionWavelength(null);
+          }
+          if (channel.getLightPath() != null) {
+            LOG.warn("Removing channel light path");
+            channel.setLightPath(null);
+          }
+          if (channel.getLightSourceSettings() != null) {
+            LOG.warn("Removing channel light source settings");
+            channel.setLightSourceSettings(null);
+          }
+          FilterSet filterSet = channel.getLinkedFilterSet();
+          if (filterSet != null) {
+            LOG.warn("Removing channel filter set");
+            channel.unlinkFilterSet(filterSet);
+          }
+          if (channel.getName() != null) {
+            LOG.warn("Removing channel name");
+            channel.setName(null);
+          }
         }
 
         // RGB data needs to have XYC* dimension order

--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -707,6 +707,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
         for (int index=0; index<pixels.sizeOfChannelList(); index++) {
           Channel channel = pixels.getChannel(index);
           channel.setSamplesPerPixel(new PositiveInteger(rgbChannels));
+          channel.setColor(null);
         }
 
         // RGB data needs to have XYC* dimension order

--- a/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
@@ -40,8 +40,6 @@ import loci.formats.tiff.TiffParser;
 import picocli.CommandLine;
 import picocli.CommandLine.ExecutionException;
 
-import ome.xml.model.primitives.Color;
-
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -494,10 +492,7 @@ public class ConversionTest {
       Assert.assertEquals(1, metadata.getChannelCount(0));
       Assert.assertEquals(
           3, metadata.getChannelSamplesPerPixel(0, 0).getNumberValue());
-      Color color =  metadata.getChannelColor(0, 0);
-      Assert.assertEquals(0, color.getRed());
-      Assert.assertEquals(255, color.getGreen());
-      Assert.assertEquals(0, color.getBlue());
+      Assert.assertNull(metadata.getChannelColor(0, 0));
     }
   }
 

--- a/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
@@ -40,6 +40,8 @@ import loci.formats.tiff.TiffParser;
 import picocli.CommandLine;
 import picocli.CommandLine.ExecutionException;
 
+import ome.xml.model.primitives.Color;
+
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -421,6 +423,20 @@ public class ConversionTest {
     assertBioFormats2Raw();
     assertTool("--rgb");
     iteratePixels();
+    try (ImageReader reader = new ImageReader()) {
+      ServiceFactory sf = new ServiceFactory();
+      OMEXMLService xmlService = sf.getInstance(OMEXMLService.class);
+      OMEXMLMetadata metadata = xmlService.createOMEXMLMetadata();
+      reader.setMetadataStore(metadata);
+      reader.setFlattenedResolutions(false);
+      reader.setId(outputOmeTiff.toString());
+      Assert.assertEquals(
+          3, metadata.getPixelsSizeC(0).getNumberValue());
+      Assert.assertEquals(1, metadata.getChannelCount(0));
+      Assert.assertEquals(
+          3, metadata.getChannelSamplesPerPixel(0, 0).getNumberValue());
+      Assert.assertNull(metadata.getChannelColor(0, 0));
+    }
   }
 
   /**
@@ -432,6 +448,57 @@ public class ConversionTest {
     assertBioFormats2Raw();
     assertTool("--rgb");
     iteratePixels();
+    try (ImageReader reader = new ImageReader()) {
+      ServiceFactory sf = new ServiceFactory();
+      OMEXMLService xmlService = sf.getInstance(OMEXMLService.class);
+      OMEXMLMetadata metadata = xmlService.createOMEXMLMetadata();
+      reader.setMetadataStore(metadata);
+      reader.setFlattenedResolutions(false);
+      reader.setId(outputOmeTiff.toString());
+      Assert.assertEquals(
+          12, metadata.getPixelsSizeC(0).getNumberValue());
+      Assert.assertEquals(4, metadata.getChannelCount(0));
+      Assert.assertEquals(
+          3, metadata.getChannelSamplesPerPixel(0, 0).getNumberValue());
+      Assert.assertNull(metadata.getChannelColor(0, 0));
+      Assert.assertEquals(
+        3, metadata.getChannelSamplesPerPixel(0, 1).getNumberValue());
+      Assert.assertNull(metadata.getChannelColor(0, 1));
+      Assert.assertEquals(
+        3, metadata.getChannelSamplesPerPixel(0, 2).getNumberValue());
+      Assert.assertNull(metadata.getChannelColor(0, 2));
+      Assert.assertEquals(
+        3, metadata.getChannelSamplesPerPixel(0, 3).getNumberValue());
+      Assert.assertNull(metadata.getChannelColor(0, 3));
+    }
+  }
+
+  /**
+   * Test RGB with multiple channels.
+   */
+  @Test
+  public void testRGBChannelColor() throws Exception {
+    input = fake("sizeC", "3", "rgb", "3", "color_0", "16711935");
+    assertBioFormats2Raw();
+    assertTool("--rgb");
+    iteratePixels();
+    try (ImageReader reader = new ImageReader()) {
+      ServiceFactory sf = new ServiceFactory();
+      OMEXMLService xmlService = sf.getInstance(OMEXMLService.class);
+      OMEXMLMetadata metadata = xmlService.createOMEXMLMetadata();
+      reader.setMetadataStore(metadata);
+      reader.setFlattenedResolutions(false);
+      reader.setId(outputOmeTiff.toString());
+      Assert.assertEquals(
+          3, metadata.getPixelsSizeC(0).getNumberValue());
+      Assert.assertEquals(1, metadata.getChannelCount(0));
+      Assert.assertEquals(
+          3, metadata.getChannelSamplesPerPixel(0, 0).getNumberValue());
+      Color color =  metadata.getChannelColor(0, 0);
+      Assert.assertEquals(0, color.getRed());
+      Assert.assertEquals(255, color.getGreen());
+      Assert.assertEquals(0, color.getBlue());
+    }
   }
 
   /**

--- a/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
@@ -434,6 +434,9 @@ public class ConversionTest {
       Assert.assertEquals(
           3, metadata.getChannelSamplesPerPixel(0, 0).getNumberValue());
       Assert.assertNull(metadata.getChannelColor(0, 0));
+      Assert.assertNull(metadata.getChannelEmissionWavelength(0, 0));
+      Assert.assertNull(metadata.getChannelExcitationWavelength(0, 0));
+      Assert.assertNull(metadata.getChannelName(0, 0));
     }
   }
 
@@ -459,24 +462,45 @@ public class ConversionTest {
       Assert.assertEquals(
           3, metadata.getChannelSamplesPerPixel(0, 0).getNumberValue());
       Assert.assertNull(metadata.getChannelColor(0, 0));
+      Assert.assertNull(metadata.getChannelEmissionWavelength(0, 0));
+      Assert.assertNull(metadata.getChannelExcitationWavelength(0, 0));
+      Assert.assertNull(metadata.getChannelName(0, 0));
       Assert.assertEquals(
         3, metadata.getChannelSamplesPerPixel(0, 1).getNumberValue());
       Assert.assertNull(metadata.getChannelColor(0, 1));
+      Assert.assertNull(metadata.getChannelEmissionWavelength(0, 1));
+      Assert.assertNull(metadata.getChannelExcitationWavelength(0, 1));
+      Assert.assertNull(metadata.getChannelName(0, 1));
       Assert.assertEquals(
         3, metadata.getChannelSamplesPerPixel(0, 2).getNumberValue());
       Assert.assertNull(metadata.getChannelColor(0, 2));
+      Assert.assertNull(metadata.getChannelEmissionWavelength(0, 2));
+      Assert.assertNull(metadata.getChannelExcitationWavelength(0, 2));
+      Assert.assertNull(metadata.getChannelName(0, 2));
       Assert.assertEquals(
         3, metadata.getChannelSamplesPerPixel(0, 3).getNumberValue());
       Assert.assertNull(metadata.getChannelColor(0, 3));
+      Assert.assertNull(metadata.getChannelEmissionWavelength(0, 3));
+      Assert.assertNull(metadata.getChannelExcitationWavelength(0, 3));
+      Assert.assertNull(metadata.getChannelName(0, 3));
     }
   }
 
   /**
-   * Test RGB with multiple channels.
+   * Test RGB with channel metadata.
    */
   @Test
-  public void testRGBChannelColor() throws Exception {
-    input = fake("sizeC", "3", "rgb", "3", "color_0", "16711935");
+  public void testRGBChannelMetadata() throws Exception {
+    Map<String, String> options = new HashMap<String, String>();
+    options.put("sizeC", "3");
+    options.put("rgb", "3");
+    options.put("color_0", "16711935");
+    Map<Integer, Map<String, String>> series =
+        new HashMap<Integer, Map<String, String>>();
+    Map<String, String> series0 = new HashMap<String, String>();
+    series0.put("ChannelName_0", "FITC");
+    series.put(0, series0);
+    input = fake(options, series);
     assertBioFormats2Raw();
     assertTool("--rgb");
     iteratePixels();
@@ -493,6 +517,9 @@ public class ConversionTest {
       Assert.assertEquals(
           3, metadata.getChannelSamplesPerPixel(0, 0).getNumberValue());
       Assert.assertNull(metadata.getChannelColor(0, 0));
+      Assert.assertNull(metadata.getChannelEmissionWavelength(0, 0));
+      Assert.assertNull(metadata.getChannelExcitationWavelength(0, 0));
+      Assert.assertNull(metadata.getChannelName(0, 0));
     }
   }
 


### PR DESCRIPTION
Primarily driven by the discussion at https://forum.image.sc/t/nikon-slide-scanner-brightfield-nd2-files-lacking-rgb-information-after-conversion-to-ome-tif-when-viewed-in-omero/76438

The scenario can be reproduced by using a file similar to

```
% cat test.fake.ini
sizeC=3
color_0=16711935
color_1=16711935
color_2=16711935
```

and either running NGFF-Converter 1.1.4 with the`--rgb` flag in the arguments list or directly:

```
% bioformats2raw test.fake test.zarr
% raw2ometiff test.zarr test.ome.tiff --rgb
```

The generated OME-TIFF is a RGB image (SizeC=3, 1 channel with SamplePerPixels=3) as expected but its Channel metadata still contains the green color information

```
 % tiffinfo ~/Downloads/test.ome.tiff 
=== TIFF directory 0 ===
TIFF Directory at offset 0x27c7f (162943)
  Image Width: 512 Image Length: 512
  Tile Width: 512 Tile Length: 512
  Resolution: 0, 0 pixels/cm
  Bits/Sample: 8
  Sample Format: unsigned integer
  Compression Scheme: LZW
  Photometric Interpretation: RGB color
  Samples/Pixel: 3
  Planar Configuration: separate image planes
  SubIFD Offsets: 162516
  ImageDescription: <?xml version="1.0" encoding="UTF-8"?><OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd"><Image ID="Image:0" Name="test"><Pixels BigEndian="true" DimensionOrder="XYCZT" ID="Pixels:0" Interleaved="false" SignificantBits="8" SizeC="3" SizeT="1" SizeX="512" SizeY="512" SizeZ="1" Type="uint8"><Channel Color="16711935" ID="Channel:0:0" SamplesPerPixel="3"><LightPath/></Channel><TiffData IFD="0" PlaneCount="1"/></Pixels></Image><StructuredAnnotations><MapAnnotation ID="Annotation:Resolution:0" Namespace="openmicroscopy.org/PyramidResolution"><Value><M K="1">256 256</M></Value></MapAnnotation></StructuredAnnotations></OME>
  Software: OME Bio-Formats 6.11.1
```

When importing such a file into OMERO, all channels are now populated as green by default. This is at odds with the user expectation when passing a `--rgb` flag.

dcb6642852e3949fbb2a1c58ab7958bfffd8c652 expands the RGB conversion tests to covert the scenario above and add channel metadata assertions
2cfbd1ec71c0ac82706608a9befbbc3b3b0885d2 proposes to change the behavior of the converter to remove the Channel.Color metadata when `--rgb` is passed and adjusts the newly introduced unit test accordingly

/cc @DavidStirling 