### PR TITLE
Expand manifest with additional properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,15 @@ test {
 jar {
     manifest {
         attributes(
-            "Main-Class": mainClassName,
-            "Implementation-Version": archiveVersion
+            "Created-By": "Gradle ${gradle.gradleVersion}",
+            "Build-Jdk": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
+            "Built-By": System.properties['user.name'],
+            "Built-On": new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(new Date()),
+            "Implementation-Build": "git rev-parse --verify HEAD".execute().getText().trim(),
+            "Implementation-Title": "raw2ometiff converter",
+            "Implementation-Version": archiveVersion,
+            "Implementation-Vendor": "Glencoe Software Inc.",
+            "Main-Class": mainClassName
         )
     }
 }


### PR DESCRIPTION
Most of these are standard keys found in the manifest. The implementation version is useful in the context of testing successful iterations of a PR (like #80) when trying to identify the revision from which a SNAPSHOT was build.