### PR TITLE
Fix progress bars for multiple planes

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -1184,8 +1184,9 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
         LOG.info("Converting resolution #{}", resolution);
         ResolutionDescriptor descriptor = s.resolutions.get(resolution);
         int tileCount = descriptor.numberOfTilesY * descriptor.numberOfTilesX;
+        int totalTileCount = tileCount * s.planeCount;
 
-        getProgressListener().notifyResolutionStart(resolution, tileCount);
+        getProgressListener().notifyResolutionStart(resolution, totalTileCount);
 
         int plane = 0;
         for (int t=0; t<s.t; t++) {


### PR DESCRIPTION
Noticed while looking at #104.

Using bioformats2raw 0.7.0, convert any dataset with multiple planes, e.g. `bioformats2raw -p "test&sizeX=50000&sizeY=50000&sizeC=10.fake" plane-test.zarr`. Using the output of bioformats2raw with `raw2ometiff -p plane-test.zarr plane-test.ome.tiff`, compare the progress bars shown with and without this PR.

Without this PR, the initial progress bar size is expected to match the number of tiles per plane, not the total tiles per resolution. After the first plane is converted, the progress bar's tile count will increase, but will show 100% complete while the remaining 9 planes are converted.

With this PR, the progress bar size should match the total number of tiles per resolution, and accurately reflect the progress of each resolution without being resized.