### PR TITLE
Add --split-planes option to write one plane per file

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -135,6 +135,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
   private List<PyramidSeries> series = new ArrayList<PyramidSeries>();
   private Map<String, TiffSaver> tiffSavers = new HashMap<String, TiffSaver>();
   boolean splitBySeries = false;
+  boolean splitByPlane = false;
 
   private ZarrGroup reader = null;
 
@@ -307,6 +308,20 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
   }
 
   /**
+   * Configure whether to write one OME-TIFF per plane.
+   *
+   * @param split true if output should be split into one OME-TIFF per plane
+   */
+  @Option(
+      names = "--split-planes",
+      description =
+        "Split output into one OME-TIFF file per plane"
+  )
+  public void setSplitSinglePlaneTIFFs(boolean split) {
+    splitByPlane = split;
+  }
+
+  /**
    * Set the maximum number of workers to use for converting tiles.
    * Defaults to the number of detected CPUs.
    *
@@ -408,6 +423,13 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
   }
 
   /**
+   * @return true if output will be split into one OME-TIFF per plane
+   */
+  public boolean getSplitSinglePlaneTIFFs() {
+    return splitByPlane;
+  }
+
+  /**
    * @return maximum number of worker threads
    */
   public int getMaxWorkers() {
@@ -475,8 +497,9 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
     setupLogger();
 
     // we could support this case later, just keeping it simple for now
-    if (splitBySeries && legacy) {
-      throw new IllegalArgumentException("--split not supported with --legacy");
+    if ((splitBySeries || splitByPlane) && legacy) {
+      throw new IllegalArgumentException(
+        "--split and --split-planes not supported with --legacy");
     }
 
     try {
@@ -1011,12 +1034,9 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
       }
 
       s.planeCount *= effectiveChannels;
-
       s.describePyramid(reader, metadata);
 
       metadata.setTiffDataIFD(new NonNegativeInteger(totalPlanes), s.index, 0);
-      metadata.setTiffDataPlaneCount(
-        new NonNegativeInteger(s.planeCount), s.index, 0);
 
       for (ResolutionDescriptor descriptor : s.resolutions) {
         LOG.info("Adding metadata for resolution: {}",
@@ -1049,22 +1069,39 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
       series.add(s);
       totalPlanes += s.planeCount;
 
-      if (splitBySeries) {
+      if (splitBySeries && !splitByPlane) {
         String basePath = getOutputPathPrefix();
         // append the series index and file extension
         basePath += "_s";
         seriesPaths.add(Paths.get(basePath + s.index + ".ome.tiff"));
         // generate one UUID per file
-        s.uuid = "urn:uuid:" + UUID.randomUUID().toString();
+        s.uuid.add("urn:uuid:" + UUID.randomUUID().toString());
+      }
+      else if (splitByPlane) {
+        String basePath = getOutputPathPrefix();
+        // append the series index and file extension
+        basePath += "_s";
+        basePath += s.index;
+        basePath += "_z";
+        for (int t=0; t<s.t; t++) {
+          for (int c=0; c<effectiveChannels; c++) {
+            for (int z=0; z<s.z; z++) {
+              seriesPaths.add(
+                Paths.get(basePath + z + "_c" + c + "_t" + t + ".ome.tiff"));
+              // generate one UUID per file
+              s.uuid.add("urn:uuid:" + UUID.randomUUID().toString());
+            }
+          }
+        }
       }
       else {
         seriesPaths.add(outputFilePath);
         // use the same UUID everywhere since we're only writing one file
         if (seriesIndex == 0) {
-          s.uuid = "urn:uuid:" + UUID.randomUUID().toString();
+          s.uuid.add("urn:uuid:" + UUID.randomUUID().toString());
         }
         else {
-          s.uuid = series.get(0).uuid;
+          s.uuid.add(series.get(0).uuid.get(0));
         }
       }
     }
@@ -1072,7 +1109,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
     populateTiffData();
     populateOriginalMetadata(service);
 
-    if (splitBySeries) {
+    if (splitBySeries || splitByPlane) {
       // splitting into separate OME-TIFFs results in a companion OME-XML file
       // the OME-TIFFs then use the BinaryOnly element to reference the OME-XML
       // for large plates in particular, this is useful as it reduces the
@@ -1137,7 +1174,19 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
     return w;
   }
 
-  private String getSeriesPathName(PyramidSeries s) {
+  private String getPathName(PyramidSeries s, int plane) {
+    if (splitByPlane) {
+      int index = 0;
+      for (int i=0; i<series.size(); i++) {
+        if (!series.get(i).equals(s)) {
+          index += series.get(i).uuid.size();
+        }
+        else {
+          break;
+        }
+      }
+      return seriesPaths.get(index + plane).toString();
+    }
     return seriesPaths.get(s.index).toString();
   }
 
@@ -1292,7 +1341,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
     long[][][] subs = new long[series.size()][][];
     for (PyramidSeries s : series) {
       StopWatch t1 = new Slf4JStopWatch("subifd-" + s.index);
-      String path = getSeriesPathName(s);
+      String path = getPathName(s, 0);
       try (RandomAccessOutputStream out = new RandomAccessOutputStream(path)) {
         out.order(s.littleEndian);
         out.seek(out.length());
@@ -1314,9 +1363,25 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
         else {
           subs[s.index] = new long[s.planeCount][s.numberOfResolutions - 1];
           for (int plane=0; plane<s.planeCount; plane++) {
-            for (int r=1; r<s.numberOfResolutions; r++) {
-              subs[s.index][plane][r - 1] = out.getFilePointer();
-              writeIFD(out, s, r, plane, r < s.numberOfResolutions - 1);
+            if (splitByPlane) {
+              String planePath = getPathName(s, plane);
+              try (RandomAccessOutputStream p =
+                new RandomAccessOutputStream(planePath))
+              {
+                p.order(s.littleEndian);
+                p.seek(p.length());
+                for (int r=1; r<s.numberOfResolutions; r++) {
+                  subs[s.index][plane][r - 1] = p.getFilePointer();
+                  writeIFD(p, s, r, plane, r < s.numberOfResolutions - 1);
+                }
+              }
+              tiffSavers.remove(planePath);
+            }
+            else {
+              for (int r=1; r<s.numberOfResolutions; r++) {
+                subs[s.index][plane][r - 1] = out.getFilePointer();
+                writeIFD(out, s, r, plane, r < s.numberOfResolutions - 1);
+              }
             }
           }
         }
@@ -1332,7 +1397,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
       firstIFDOffsets.clear();
       for (PyramidSeries s : series) {
         StopWatch t1 = new Slf4JStopWatch("fullResolution-" + s.index);
-        String path = getSeriesPathName(s);
+        String path = getPathName(s, 0);
         try (RandomAccessOutputStream out =
           new RandomAccessOutputStream(path))
         {
@@ -1345,14 +1410,33 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
 
           for (int plane=0; plane<s.planeCount; plane++) {
             s.ifds[0].get(plane).put(IFD.SUB_IFD, subs[s.index][plane]);
-            boolean overwrite = plane < s.planeCount - 1;
-            if (!splitBySeries) {
-              overwrite = overwrite || s.index < series.size() - 1;
+            // if splitting by plane, the first IFD is also the last in the file
+            if (!splitByPlane) {
+              boolean overwrite = plane < s.planeCount - 1;
+              if (!splitBySeries) {
+                overwrite = overwrite || s.index < series.size() - 1;
+              }
+              writeIFD(out, s, 0, plane, overwrite);
             }
-            writeIFD(out, s, 0, plane, overwrite);
+            else {
+              String planePath = getPathName(s, plane);
+              try (RandomAccessOutputStream p =
+                new RandomAccessOutputStream(planePath))
+              {
+                p.order(s.littleEndian);
+                long offset = p.length();
+                p.seek(offset);
+                writeIFD(p, s, 0, plane, false);
+                p.seek(FIRST_IFD_OFFSET);
+                p.writeLong(offset);
+              }
+              tiffSavers.remove(planePath);
+            }
           }
-          out.seek(FIRST_IFD_OFFSET);
-          out.writeLong(firstIFDOffsets.get(path));
+          if (!splitByPlane) {
+            out.seek(FIRST_IFD_OFFSET);
+            out.writeLong(firstIFDOffsets.get(path));
+          }
         }
         tiffSavers.remove(path);
         t1.stop();
@@ -1451,18 +1535,18 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
     }
 
     // only write the OME-XML to the first full-resolution IFD
-    if (resolution == 0 && plane == 0) {
-      if (splitBySeries) {
+    if (resolution == 0 && (plane == 0 || splitByPlane)) {
+      if (splitBySeries || splitByPlane) {
         // if each series is in a separate OME-TIFF, store BinaryOnly OME-XML
         // that references the companion OME-XML file
 
-        String omexml = getBinaryOnlyOMEXML(s);
+        String omexml = getBinaryOnlyOMEXML(s, plane);
         ifd.put(IFD.IMAGE_DESCRIPTION, omexml);
       }
       else if (s.index == 0) {
         // if everything is in one OME-TIFF file, store the complete OME-XML
         try {
-          metadata.setUUID(s.uuid);
+          metadata.setUUID(s.uuid.get(0));
           OMEXMLService service = getService();
           String omexml = service.getOMEXML(metadata);
           ifd.put(IFD.IMAGE_DESCRIPTION, omexml);
@@ -1562,7 +1646,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
     long[] byteCounts = ifd.getIFDLongArray(IFD.TILE_BYTE_COUNTS);
     byteCounts[tileIndex] = (long) realTile.length;
 
-    String file = getSeriesPathName(s);
+    String file = getPathName(s, imageNumber);
     try (RandomAccessOutputStream out = new RandomAccessOutputStream(file)) {
       out.seek(out.length());
       offsets[tileIndex] = out.getFilePointer();
@@ -1601,7 +1685,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
     PyramidSeries s, int resolution, int plane, boolean overwrite)
     throws FormatException, IOException
   {
-    TiffSaver writer = createTiffSaver(outStream, getSeriesPathName(s));
+    TiffSaver writer = createTiffSaver(outStream, getPathName(s, plane));
     int ifdSize = getIFDSize(s.ifds[resolution].get(plane));
     long offsetPointer = outStream.getFilePointer() + ifdSize;
     writer.writeIFD(s.ifds[resolution].get(plane), 0);
@@ -1646,11 +1730,31 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
 
   private void populateTiffData() {
     for (PyramidSeries s : series) {
-      metadata.setUUIDFileName(
-        Paths.get(getSeriesPathName(s)).getFileName().toString(), s.index, 0);
-      metadata.setUUIDValue(s.uuid, s.index, 0);
-      if (splitBySeries) {
-        metadata.setTiffDataIFD(new NonNegativeInteger(0), s.index, 0);
+      for (int tiffData=0; tiffData<s.uuid.size(); tiffData++) {
+        String path = getPathName(s, tiffData);
+        metadata.setUUIDFileName(
+          Paths.get(path).getFileName().toString(), s.index, tiffData);
+        metadata.setUUIDValue(s.uuid.get(tiffData), s.index, tiffData);
+
+        if (splitByPlane) {
+          int[] zct = s.getZCTCoords(tiffData);
+          metadata.setTiffDataFirstZ(
+            new NonNegativeInteger(zct[0]), s.index, tiffData);
+          metadata.setTiffDataFirstC(
+            new NonNegativeInteger(zct[1]), s.index, tiffData);
+          metadata.setTiffDataFirstT(
+            new NonNegativeInteger(zct[2]), s.index, tiffData);
+          metadata.setTiffDataPlaneCount(
+            new NonNegativeInteger(1), s.index, tiffData);
+        }
+        else {
+          metadata.setTiffDataPlaneCount(
+            new NonNegativeInteger(s.planeCount), s.index, tiffData);
+        }
+
+        if (splitBySeries || splitByPlane) {
+          metadata.setTiffDataIFD(new NonNegativeInteger(0), s.index, tiffData);
+        }
       }
     }
   }
@@ -1662,9 +1766,10 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
    * to have BinaryOnly OME-XML that references the companion OME-XML file.
    *
    * @param s pyramid series for UUID retrieval
+   * @param plane plane index for UUID retrieval
    * @return corresponding BinaryOnly OME-XML string
    */
-  private String getBinaryOnlyOMEXML(PyramidSeries s) {
+  private String getBinaryOnlyOMEXML(PyramidSeries s, int plane) {
     try {
       OMEXMLService service = getService();
       if (binaryOnly == null) {
@@ -1675,11 +1780,11 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
           companion.getName(companion.getNameCount() - 1).toString());
         binaryOnly.setBinaryOnlyUUID(companionUUID);
       }
-      binaryOnly.setUUID(s.uuid);
+      binaryOnly.setUUID(s.uuid.get(plane));
       return service.getOMEXML(binaryOnly);
     }
     catch (DependencyException | ServiceException e) {
-      LOG.warn("Could not create OME-XML for " + getSeriesPathName(s), e);
+      LOG.warn("Could not create OME-XML for " + getPathName(s, plane), e);
     }
     return null;
   }

--- a/src/main/java/com/glencoesoftware/pyramid/PyramidSeries.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidSeries.java
@@ -28,7 +28,7 @@ public class PyramidSeries {
   /** Path to series. */
   String path;
 
-  String uuid;
+  List<String> uuid = new ArrayList<String>();
 
   int index = -1;
 

--- a/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
@@ -98,17 +98,20 @@ public class ConversionTest {
    * @param additionalArgs CLI arguments as needed beyond "input output"
    */
   void assertTool(String...additionalArgs) throws IOException {
-    assertTool(0, additionalArgs);
+    assertTool(0, 0, additionalArgs);
   }
 
   /**
    * Run the PyramidFromDirectoryWriter main method and check for success or
    * failure.
    *
+   * @param seriesCount number of series to expect, if splitting
    * @param fileCount number of files to expect, if splitting
    * @param additionalArgs CLI arguments as needed beyond "input output"
    */
-  void assertTool(int fileCount, String...additionalArgs) throws IOException {
+  void assertTool(int seriesCount, int fileCount, String...additionalArgs)
+    throws IOException
+  {
     List<String> args = new ArrayList<String>();
     for (String arg : additionalArgs) {
       args.add(arg);
@@ -122,7 +125,7 @@ public class ConversionTest {
       if (fileCount == 0) {
         Assert.assertTrue(Files.exists(outputOmeTiff));
       }
-      else {
+      else if (seriesCount == fileCount) {
         String prefix = output.resolve("output").toString();
         for (int i=0; i<fileCount; i++) {
           Assert.assertTrue(Files.exists(
@@ -131,6 +134,14 @@ public class ConversionTest {
         Assert.assertFalse(Files.exists(
             Paths.get(prefix + "_s" +
             fileCount + ".ome.tiff")));
+      }
+      else {
+        String prefix = output.resolve("output").toString();
+        for (int i=0; i<seriesCount; i++) {
+          Assert.assertTrue(Files.exists(
+            Paths.get(prefix + "_s" + i + "_z0_c0_t0.ome.tiff")));
+        }
+        Assert.assertFalse(Files.exists(Paths.get(prefix + "_s0.ome.tiff")));
       }
     }
     catch (RuntimeException rt) {
@@ -629,7 +640,7 @@ public class ConversionTest {
     input =
       fake("plateRows", "2", "plateCols", "3", "fields", "4", "sizeC", "3");
     assertBioFormats2Raw();
-    assertTool(24, "--split");
+    assertTool(24, 24, "--split");
 
     try (ImageReader reader = new ImageReader()) {
       ServiceFactory sf = new ServiceFactory();
@@ -643,6 +654,68 @@ public class ConversionTest {
       reader.setId(output.resolve("output").toString() + ".companion.ome");
 
       Assert.assertEquals(reader.getUsedFiles().length, 25);
+      Assert.assertEquals(reader.getSeriesCount(), 24);
+      Assert.assertEquals(1, metadata.getPlateCount());
+      Assert.assertEquals(24, metadata.getImageCount());
+
+      iteratePixels(reader);
+    }
+  }
+
+  /**
+   * Test splitting planes into separate files.
+   */
+  @Test
+  public void testSplitPlanes() throws Exception {
+    input =
+      fake("plateRows", "2", "plateCols", "3", "fields", "4", "sizeC", "3");
+    assertBioFormats2Raw();
+    assertTool(24, 72, "--split-planes");
+
+    try (ImageReader reader = new ImageReader()) {
+      ServiceFactory sf = new ServiceFactory();
+      OMEXMLService xmlService = sf.getInstance(OMEXMLService.class);
+      OMEXMLMetadata metadata = xmlService.createOMEXMLMetadata();
+      reader.setMetadataStore(metadata);
+      reader.setFlattenedResolutions(false);
+
+      // --split-planes should always produce a companion OME-XML file
+      // with BinaryOnly OME-TIFFs
+      reader.setId(output.resolve("output").toString() + ".companion.ome");
+
+      Assert.assertEquals(reader.getUsedFiles().length, 73);
+      Assert.assertEquals(reader.getSeriesCount(), 24);
+      Assert.assertEquals(1, metadata.getPlateCount());
+      Assert.assertEquals(24, metadata.getImageCount());
+
+      iteratePixels(reader);
+    }
+  }
+
+  /**
+   * Test what happens when the split-by-series and split-by-plane
+   * options are used together.
+   */
+  @Test
+  public void testBothSplitOptions() throws Exception {
+    input =
+      fake("plateRows", "2", "plateCols", "3", "fields", "4", "sizeC", "3");
+    assertBioFormats2Raw();
+    // expect --split-planes to take precedence
+    assertTool(24, 72, "--split", "--split-planes");
+
+    try (ImageReader reader = new ImageReader()) {
+      ServiceFactory sf = new ServiceFactory();
+      OMEXMLService xmlService = sf.getInstance(OMEXMLService.class);
+      OMEXMLMetadata metadata = xmlService.createOMEXMLMetadata();
+      reader.setMetadataStore(metadata);
+      reader.setFlattenedResolutions(false);
+
+      // --split-planes should always produce a companion OME-XML file
+      // with BinaryOnly OME-TIFFs
+      reader.setId(output.resolve("output").toString() + ".companion.ome");
+
+      Assert.assertEquals(reader.getUsedFiles().length, 73);
       Assert.assertEquals(reader.getSeriesCount(), 24);
       Assert.assertEquals(1, metadata.getPlateCount());
       Assert.assertEquals(24, metadata.getImageCount());


### PR DESCRIPTION
Fixes #107.

Default and `--split` behavior should remain unchanged. Using `--split-planes` writes each plane's pyramid to a separate file. If both `--split-planes` and `--split` are used, `--split-planes` takes precedence.

As mentioned in #107, I'd really prefer not to add more flexibility than this to the OME-TIFF layout; as we've seen with `bfconvert`, even seemingly simple configurability can add a lot of complexity. With this change, though, there are now 3 options:

- everything in one big OME-TIFF file (default)
- each series/Image pyramid in one file (`--split`)
- each plane pyramid in one file (`--split-planes`)

e.g. for a 96 well x 4 fields x 3 channels plate, these options would result in 1, 384, and 1152 files respectively.