### PR TITLE
Fix RGB ZCT coordinate calculation

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidSeries.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidSeries.java
@@ -141,7 +141,9 @@ public class PyramidSeries {
    * @return array of Z, C, and T indexes
    */
   public int[] getZCTCoords(int plane) {
-    return FormatTools.getZCTCoords(dimensionOrder, z, c, t, planeCount, plane);
+    int effectiveC = rgb ? c / 3 : c;
+    return FormatTools.getZCTCoords(
+      dimensionOrder, z, effectiveC, t, planeCount, plane);
   }
 
   /**


### PR DESCRIPTION
As reported by @sbesson, a simple conversion with the `--rgb` flag logs numerous `IllegalArgumentException`s indicating that the ZCT coordinates could not be calculated.

Without this PR, the build passes, indicating that the unit tests that use the `--rgb` test also pass. However, examining the test output in `build/reports/tests/test/classes/` will show similar `IllegalArgumentException`s in the `Standard error` section of the test report. The ZCT coordinate calculation is only requested in https://github.com/glencoesoftware/raw2ometiff/blob/master/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java#L1537, to get the correct plane index for progress notifications. This happens after the tile has already been written; effectively, it is just the progress notification that is failing. This explains why the test does not fail; the actual conversion does in fact succeed and the output file is valid and readable.

With this PR, the `IllegalArgumentException`s should no longer appear in the test report or conversion output. The actual output OME-TIFF with and without this PR should be unchanged.