### PR TITLE
Interleave channels when the --rgb flag is used

### DIFF
--- a/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
@@ -473,6 +473,7 @@ public class ConversionTest {
       Assert.assertNull(metadata.getChannelExcitationWavelength(0, 0));
       Assert.assertNull(metadata.getChannelName(0, 0));
     }
+    checkRGBIFDs();
   }
 
   /**
@@ -519,6 +520,7 @@ public class ConversionTest {
       Assert.assertNull(metadata.getChannelExcitationWavelength(0, 3));
       Assert.assertNull(metadata.getChannelName(0, 3));
     }
+    checkRGBIFDs();
   }
 
   /**
@@ -556,6 +558,7 @@ public class ConversionTest {
       Assert.assertNull(metadata.getChannelExcitationWavelength(0, 0));
       Assert.assertNull(metadata.getChannelName(0, 0));
     }
+    checkRGBIFDs();
   }
 
   /**
@@ -668,6 +671,7 @@ public class ConversionTest {
     apiConverter.call();
 
     iteratePixels();
+    checkRGBIFDs();
   }
 
   /**
@@ -685,6 +689,7 @@ public class ConversionTest {
       Assert.assertEquals(1, reader.getSeriesCount());
       Assert.assertEquals(3, reader.getRGBChannelCount());
     }
+    checkRGBIFDs();
   }
 
   /**
@@ -696,6 +701,22 @@ public class ConversionTest {
   public void testVersionOnly() throws Exception {
     CommandLine.call(
       new PyramidFromDirectoryWriter(), new String[] {"--version"});
+  }
+
+  private void checkRGBIFDs() throws FormatException, IOException {
+    try (TiffParser parser = new TiffParser(outputOmeTiff.toString())) {
+      IFDList mainIFDs = parser.getMainIFDs();
+      for (IFD ifd : mainIFDs) {
+        Assert.assertEquals(1, ifd.getPlanarConfiguration());
+        Assert.assertEquals(3, ifd.getSamplesPerPixel());
+
+        IFDList subresolutions = parser.getSubIFDs(ifd);
+        for (IFD subres : subresolutions) {
+          Assert.assertEquals(1, subres.getPlanarConfiguration());
+          Assert.assertEquals(3, ifd.getSamplesPerPixel());
+        }
+      }
+    }
   }
 
 }


### PR DESCRIPTION
This packs the RGB channels into a single tile (TIFF PlanarConfiguration 1), rather than using a separate tile per RGB channel. This has a noticeable effect on JPEG and JPEG-2000 compression for brightfield slides.

The scary-looking part of this diff is reworking how the RGB channels are iterated over. Instead of a call to `writeTile` for each RGB channel, all RGB channels for the current tile are read, then repacked, and then written once. For the common case where `--rgb` is not used (i.e. `rgbChannels == 1`), there should be no difference in behavior.

For the case where `rgbChannels == 3`, check with both default compression and `--compression JPEG` and/or `--compression JPEG-2000`. `tiffdump` on the output file should show that the `PlanarConfiguration` tag is changed with this PR; the file sizes should also be noticeably different with JPEG and JPEG-2000 compression. In local testing with `CMU-1.svs`, the output OME-TIFF is now approximately the same size as the original input file.

You may wish to test this together with #112, as testing this PR without the changes in #112 will result in harmless but alarming `IllegalArgumentException`s.

