### PR TITLE
Check for interrupts before initializing each series

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -839,7 +839,8 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
    * After this method is called, image data can be written.
    */
   public void initialize()
-    throws FormatException, IOException, DependencyException
+    throws FormatException, InterruptedException,
+      IOException, DependencyException
   {
     createReader();
 
@@ -905,6 +906,9 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
     int totalPlanes = 0;
     seriesPaths = new ArrayList<Path>(seriesCount);
     for (int seriesIndex=0; seriesIndex<seriesCount; seriesIndex++) {
+      if (Thread.currentThread().isInterrupted()) {
+        throw new InterruptedException("Stopping in series " + seriesIndex);
+      }
       PyramidSeries s = new PyramidSeries();
       s.index = seriesIndex;
       findNumberOfResolutions(s);


### PR DESCRIPTION
@DavidStirling noted that cancelling the raw2ometiff step in NGFF-Converter (by calling `interrupt()` on the thread that runs raw2ometiff) doesn't result in the thread actually stopping until `PyramidFromDirectoryWriter.initialize()` finishes. For large HCS datasets, this can take a while. I was able to reproduce this behavior.

With this change included in a build of NGFF-Converter, cancelling the raw2ometiff step during initialization should now happen much more quickly. The logs should include a line indicating that `InterruptedException` was thrown.

This feels like a not-great solution and like I'm missing something obvious, although this approach is at least similar to what `com.glencoesoftware.pyramid.LimitedQueue` already does. I don't have any better ideas at the moment, but happy to hear other thoughts (@sbesson / @chris-allan / @kkoz?)