### PR TITLE
Use a single ThreadPoolExecutor and add a getter

### DIFF
--- a/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
@@ -710,18 +710,25 @@ public class ConversionTest {
     Assert.assertEquals(apiConverter.getRGB(), false);
     Assert.assertEquals(apiConverter.getLegacyTIFF(), false);
     Assert.assertEquals(apiConverter.getSplitTIFFs(), false);
+    Assert.assertNotNull(apiConverter.getTileExecutor());
+    Assert.assertEquals(
+      apiConverter.getTileExecutor().getCorePoolSize(),
+      Math.min(4, Runtime.getRuntime().availableProcessors()));
 
     // update options, make sure they were set, and actually convert
     apiConverter.setInputPath(output.toString());
     apiConverter.setOutputPath(outputOmeTiff.toString());
     apiConverter.setCompression(CompressionType.UNCOMPRESSED);
     apiConverter.setRGB(true);
+    apiConverter.setMaxWorkers(1);
 
     Assert.assertEquals(apiConverter.getInputPath(), output.toString());
     Assert.assertEquals(apiConverter.getOutputPath(), outputOmeTiff.toString());
     Assert.assertEquals(apiConverter.getCompression(),
       CompressionType.UNCOMPRESSED);
     Assert.assertEquals(apiConverter.getRGB(), true);
+    Assert.assertNotNull(apiConverter.getTileExecutor());
+    Assert.assertEquals(apiConverter.getTileExecutor().getCorePoolSize(), 1);
 
     apiConverter.call();
 


### PR DESCRIPTION
Similar to https://github.com/glencoesoftware/bioformats2raw/pull/230, this adds a getter for the `ThreadPoolExecutor`. The executor usage is also modified so that a single `ThreadPoolExecutor` is used for the whole conversion, instead of one per resolution.

This approach is consistent with what bioformats2raw does already, but it's worth double-checking a conversion with more than 1 worker to verify that output OME-TIFF is still valid.