### PR TITLE
Bump to bioformats2raw 0.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation 'info.picocli:picocli:4.7.5'
     implementation 'me.tongfei:progressbar:0.9.0'
     implementation 'ome:formats-bsd:7.0.1'
-    implementation 'com.glencoesoftware:bioformats2raw:0.8.0-rc1'
+    implementation 'com.glencoesoftware:bioformats2raw:0.8.0'
     implementation 'org.json:json:20230227'
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.13'
     implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.3.13'


### PR DESCRIPTION
Build will fail as 0.8.0 is not quite yet released, this is just getting everything ready for 0.6.0.