### PR TITLE
Allow individual label images to be converted

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -37,7 +37,6 @@
 
     <!-- Checks for Size Violations.                    -->
     <!-- See https://checkstyle.org/config_sizes.html -->
-    <module name="FileLength"/>
     <module name="LineLength">
       <property name="fileExtensions" value="java"/>
     </module>

--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -999,8 +999,11 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
 
     int seriesCount = getSeriesCount();
 
+    boolean flatHierarchy = false;
     if (seriesCount < 1) {
-      throw new FormatException("Found no images to convert.  Corrupt input?");
+      LOG.warn("Series missing from hierarchy, assuming single pyramid");
+      seriesCount = 1;
+      flatHierarchy = true;
     }
 
     if (seriesCount > 1 && legacy) {
@@ -1032,7 +1035,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
       for (int seriesIndex=0; seriesIndex<seriesCount; seriesIndex++) {
         PyramidSeries s = new PyramidSeries();
         s.index = seriesIndex;
-        s.path = String.valueOf(s.index);
+        s.path = flatHierarchy ? "" : String.valueOf(s.index);
         series.set(s.index, s);
       }
     }

--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -360,7 +360,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
    * Set an alternate file to use for obtaining OME-XML metadata
    * If the expected "OME/METADATA.ome.xml" file is not found, then
    * the provided file will be read using Bio-Formats.
-   * This file is expected to be an original image file, with dimensions
+   * This file is expected to be an original image file, with XYZT dimensions
    * that match the input Zarr.
    *
    * @param file path to image file

--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -1035,7 +1035,19 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
       for (int seriesIndex=0; seriesIndex<seriesCount; seriesIndex++) {
         PyramidSeries s = new PyramidSeries();
         s.index = seriesIndex;
-        s.path = flatHierarchy ? "" : String.valueOf(s.index);
+        s.path = String.valueOf(s.index);
+        if (flatHierarchy) {
+          try {
+            // if we're skipping the series in the hierarchy,
+            // check that there is actually an array at the resolution level
+            ZarrArray.open(inputDirectory.resolve("0"));
+            s.path = "";
+          }
+          catch (IOException e) {
+            throw new FormatException(
+              "Could not handle series index " + s.index + ". Corrupt input?");
+          }
+        }
         series.set(s.index, s);
       }
     }

--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -1076,7 +1076,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
       for (int d=0; d<dims.length; d++) {
         if (dims[d] != metadataDims[d]) {
           throw new FormatException("Dimension mismatch: " +
-            ("TZCYX".charAt(d)) + ": Zarr (" + dims[d] + "), OME-XML: (" +
+            ("TCZYX".charAt(d)) + ": Zarr (" + dims[d] + "), OME-XML: (" +
             metadataDims[d] + ")");
         }
       }

--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -1061,9 +1061,26 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
       }
       findNumberOfResolutions(s);
 
+      int x = metadata.getPixelsSizeX(seriesIndex).getNumberValue().intValue();
+      int y = metadata.getPixelsSizeY(seriesIndex).getNumberValue().intValue();
+
       s.z = metadata.getPixelsSizeZ(seriesIndex).getNumberValue().intValue();
       s.c = metadata.getPixelsSizeC(seriesIndex).getNumberValue().intValue();
       s.t = metadata.getPixelsSizeT(seriesIndex).getNumberValue().intValue();
+
+      // make sure that OME-XML and first resolution array have same dimensions
+      ZarrGroup imgGroup = getZarrGroup(s.path);
+      ZarrArray imgArray = imgGroup.openArray("0");
+      int[] dims = imgArray.getShape();
+      int[] metadataDims = new int[] {s.t, s.c, s.z, y, x};
+      for (int d=0; d<dims.length; d++) {
+        if (dims[d] != metadataDims[d]) {
+          throw new FormatException("Dimension mismatch: " +
+            ("TZCYX".charAt(d)) + ": Zarr (" + dims[d] + "), OME-XML: (" +
+            metadataDims[d] + ")");
+        }
+      }
+
       s.dimensionOrder =
         metadata.getPixelsDimensionOrder(seriesIndex).toString();
       s.planeCount = s.z * s.t;

--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -965,6 +965,7 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
       else if (imageFile != null && !imageFile.isEmpty()) {
         try (ChannelSeparator imageReader = new ChannelSeparator()) {
           IMetadata srcMetadata = service.createOMEXMLMetadata();
+          imageReader.setFlattenedResolutions(false);
           imageReader.setMetadataStore(srcMetadata);
           imageReader.setId(imageFile);
           xml = service.getOMEXML(srcMetadata);

--- a/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
@@ -477,12 +477,8 @@ public class ConversionTest {
       Assert.assertEquals(
           3, metadata.getPixelsSizeC(0).getNumberValue());
       Assert.assertEquals(1, metadata.getChannelCount(0));
-      Assert.assertEquals(
-          3, metadata.getChannelSamplesPerPixel(0, 0).getNumberValue());
-      Assert.assertNull(metadata.getChannelColor(0, 0));
-      Assert.assertNull(metadata.getChannelEmissionWavelength(0, 0));
-      Assert.assertNull(metadata.getChannelExcitationWavelength(0, 0));
-      Assert.assertNull(metadata.getChannelName(0, 0));
+
+      checkRGBChannel(metadata, 0, 0);
     }
     checkRGBIFDs();
   }
@@ -506,30 +502,10 @@ public class ConversionTest {
       Assert.assertEquals(
           12, metadata.getPixelsSizeC(0).getNumberValue());
       Assert.assertEquals(4, metadata.getChannelCount(0));
-      Assert.assertEquals(
-          3, metadata.getChannelSamplesPerPixel(0, 0).getNumberValue());
-      Assert.assertNull(metadata.getChannelColor(0, 0));
-      Assert.assertNull(metadata.getChannelEmissionWavelength(0, 0));
-      Assert.assertNull(metadata.getChannelExcitationWavelength(0, 0));
-      Assert.assertNull(metadata.getChannelName(0, 0));
-      Assert.assertEquals(
-        3, metadata.getChannelSamplesPerPixel(0, 1).getNumberValue());
-      Assert.assertNull(metadata.getChannelColor(0, 1));
-      Assert.assertNull(metadata.getChannelEmissionWavelength(0, 1));
-      Assert.assertNull(metadata.getChannelExcitationWavelength(0, 1));
-      Assert.assertNull(metadata.getChannelName(0, 1));
-      Assert.assertEquals(
-        3, metadata.getChannelSamplesPerPixel(0, 2).getNumberValue());
-      Assert.assertNull(metadata.getChannelColor(0, 2));
-      Assert.assertNull(metadata.getChannelEmissionWavelength(0, 2));
-      Assert.assertNull(metadata.getChannelExcitationWavelength(0, 2));
-      Assert.assertNull(metadata.getChannelName(0, 2));
-      Assert.assertEquals(
-        3, metadata.getChannelSamplesPerPixel(0, 3).getNumberValue());
-      Assert.assertNull(metadata.getChannelColor(0, 3));
-      Assert.assertNull(metadata.getChannelEmissionWavelength(0, 3));
-      Assert.assertNull(metadata.getChannelExcitationWavelength(0, 3));
-      Assert.assertNull(metadata.getChannelName(0, 3));
+
+      for (int c=0; c<metadata.getChannelCount(0); c++) {
+        checkRGBChannel(metadata, 0, c);
+      }
     }
     checkRGBIFDs();
   }
@@ -562,12 +538,7 @@ public class ConversionTest {
       Assert.assertEquals(
           3, metadata.getPixelsSizeC(0).getNumberValue());
       Assert.assertEquals(1, metadata.getChannelCount(0));
-      Assert.assertEquals(
-          3, metadata.getChannelSamplesPerPixel(0, 0).getNumberValue());
-      Assert.assertNull(metadata.getChannelColor(0, 0));
-      Assert.assertNull(metadata.getChannelEmissionWavelength(0, 0));
-      Assert.assertNull(metadata.getChannelExcitationWavelength(0, 0));
-      Assert.assertNull(metadata.getChannelName(0, 0));
+      checkRGBChannel(metadata, 0, 0);
     }
     checkRGBIFDs();
   }
@@ -956,6 +927,59 @@ public class ConversionTest {
     iteratePixels();
   }
 
+  /**
+   * Test conversion of single multiscales (label image) with 3 channels
+   * and RGB output.
+   */
+  @Test
+  public void testRGBLabelImage() throws Exception {
+    input = fake("sizeC", "3", "rgb", "3");
+    assertBioFormats2Raw();
+    output = output.resolve("0");
+    assertTool("--rgb", "-f", input.toString());
+    iteratePixels();
+    try (ImageReader reader = new ImageReader()) {
+      ServiceFactory sf = new ServiceFactory();
+      OMEXMLService xmlService = sf.getInstance(OMEXMLService.class);
+      OMEXMLMetadata metadata = xmlService.createOMEXMLMetadata();
+      reader.setMetadataStore(metadata);
+      reader.setFlattenedResolutions(false);
+      reader.setId(outputOmeTiff.toString());
+      Assert.assertEquals(
+          3, metadata.getPixelsSizeC(0).getNumberValue());
+      Assert.assertEquals(1, metadata.getChannelCount(0));
+      checkRGBChannel(metadata, 0, 0);
+    }
+    checkRGBIFDs();
+  }
+
+  /**
+   * Test conversion of single multiscales (label image) with 3 channels
+   * and RGB output, and mismatching input channel counts.
+   */
+  @Test
+  public void testRGBLabelImageDifferentC() throws Exception {
+    input = fake("sizeC", "3", "rgb", "3");
+    assertBioFormats2Raw();
+    output = output.resolve("0");
+    assertTool("--rgb", "-f", fake("sizeC", "4").toString());
+    iteratePixels();
+    try (ImageReader reader = new ImageReader()) {
+      ServiceFactory sf = new ServiceFactory();
+      OMEXMLService xmlService = sf.getInstance(OMEXMLService.class);
+      OMEXMLMetadata metadata = xmlService.createOMEXMLMetadata();
+      reader.setMetadataStore(metadata);
+      reader.setFlattenedResolutions(false);
+      reader.setId(outputOmeTiff.toString());
+      Assert.assertEquals(
+          3, metadata.getPixelsSizeC(0).getNumberValue());
+      Assert.assertEquals(1, metadata.getChannelCount(0));
+
+      checkRGBChannel(metadata, 0, 0);
+    }
+    checkRGBIFDs();
+  }
+
   private void checkRGBIFDs() throws FormatException, IOException {
     try (TiffParser parser = new TiffParser(outputOmeTiff.toString())) {
       IFDList mainIFDs = parser.getMainIFDs();
@@ -970,6 +994,15 @@ public class ConversionTest {
         }
       }
     }
+  }
+
+  private void checkRGBChannel(OMEXMLMetadata metadata, int image, int c) {
+    Assert.assertEquals(
+        3, metadata.getChannelSamplesPerPixel(image, c).getNumberValue());
+    Assert.assertNull(metadata.getChannelColor(image, c));
+    Assert.assertNull(metadata.getChannelEmissionWavelength(image, c));
+    Assert.assertNull(metadata.getChannelExcitationWavelength(image, c));
+    Assert.assertNull(metadata.getChannelName(image, c));
   }
 
   /**

--- a/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
@@ -349,9 +349,7 @@ public class ConversionTest {
       assertTool();
     }
     catch (ExecutionException e) {
-      // First cause is RuntimeException wrapping the checked FormatException
-      Assert.assertEquals(
-          FormatException.class, e.getCause().getCause().getClass());
+      testException(FormatException.class, e);
       return;
     }
     Assert.fail("Did not throw exception on invalid data");
@@ -850,7 +848,8 @@ public class ConversionTest {
 
   /**
    * Test conversion of a single multiscales (similar to label image),
-   * but intentionally provide incorrect image metadata.
+   * but intentionally provide incorrect XY metadata.
+   * Conversion is expected to fail in this case.
    */
   @Test
   public void testLabelImageWrongSize() throws Exception {
@@ -861,9 +860,47 @@ public class ConversionTest {
       assertTool("-f", "test.fake");
     }
     catch (ExecutionException e) {
-      // First cause is RuntimeException wrapping the checked FormatException
-      Assert.assertEquals(
-          FormatException.class, e.getCause().getCause().getClass());
+      testException(FormatException.class, e);
+      return;
+    }
+    Assert.fail("Did not throw exception on invalid data");
+  }
+
+  /**
+   * Test conversion of a single multiscales (similar to label image),
+   * but intentionally provide incorrect T metadata.
+   * Conversion is expected to fail in this case.
+   */
+  @Test
+  public void testLabelImageWrongT() throws Exception {
+    input = fake();
+    assertBioFormats2Raw();
+    output = output.resolve("0");
+    try {
+      assertTool("-f", fake("sizeT", "5").toString());
+    }
+    catch (ExecutionException e) {
+      testException(FormatException.class, e);
+      return;
+    }
+    Assert.fail("Did not throw exception on invalid data");
+  }
+
+  /**
+   * Test conversion of a single multiscales (similar to label image),
+   * but intentionally provide incorrect Z metadata.
+   * Conversion is expected to fail in this case.
+   */
+  @Test
+  public void testLabelImageWrongZ() throws Exception {
+    input = fake();
+    assertBioFormats2Raw();
+    output = output.resolve("0");
+    try {
+      assertTool("-f", fake("sizeZ", "4").toString());
+    }
+    catch (ExecutionException e) {
+      testException(FormatException.class, e);
       return;
     }
     Assert.fail("Did not throw exception on invalid data");
@@ -933,6 +970,18 @@ public class ConversionTest {
         }
       }
     }
+  }
+
+  /**
+   * Check that the underlying cause of an exception matches the given class.
+   * This is used to check that e.g. RuntimeException wraps an underlying
+   * FormatException as expected.
+   *
+   * @param cause Class of expected underlying exception
+   * @param e exception that was thrown
+   */
+  private void testException(Class cause, Exception e) {
+    Assert.assertEquals(cause, e.getCause().getCause().getClass());
   }
 
 }

--- a/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
@@ -834,6 +834,37 @@ public class ConversionTest {
       new PyramidFromDirectoryWriter(), new String[] {"--version"});
   }
 
+  /**
+   * Test conversion of a single multiscales, similar to a label image.
+   */
+  @Test
+  public void testLabelImage() throws Exception {
+    input = fake("sizeX", "2000", "sizeY", "1500");
+    assertBioFormats2Raw();
+    output = output.resolve("0");
+    assertTool("-f", input.toString());
+    iteratePixels();
+  }
+
+  /**
+   * Test conversion of a single multiscales (similar to label image),
+   * but intentionally provide incorrect image metadata.
+   */
+  @Test
+  public void testLabelImageWrongSize() throws Exception {
+    input = fake("sizeX", "2000", "sizeY", "1500");
+    assertBioFormats2Raw();
+    output = output.resolve("0");
+    try {
+      assertTool("-f", "test.fake");
+    }
+    catch (ExecutionException e) {
+      // First cause is RuntimeException wrapping the checked FormatException
+      Assert.assertEquals(
+          FormatException.class, e.getCause().getCause().getClass());
+    }
+  }
+
   private void checkRGBIFDs() throws FormatException, IOException {
     try (TiffParser parser = new TiffParser(outputOmeTiff.toString())) {
       IFDList mainIFDs = parser.getMainIFDs();


### PR DESCRIPTION
This loosens some of the restrictions on the Zarr hierarchy, and adds a `-f` option so that metadata can be copied from an existing image file.

I'd expect `raw2ometiff input.zarr/0/labels/abc_mask/ mask.ome.tiff -f /path/to/original/image/file` to be the pattern to use here, which would convert a single label image to a single OME-TIFF. If there are multiple label images under `input.zarr/0/labels/`, they would each need to be converted separately. The use of `-f` means that `input.zarr/OME/METADATA.ome.xml` does not need to exist (and in fact, would be ignored if it did).

[Fake data](https://bio-formats.readthedocs.io/en/latest/developers/generating-test-images.html) can easily be used to test the `-f` option. If any of the XYZCT dimensions are incorrect, an informative exception should be thrown.

Assigning just @erindiel for now to make sure the required functionality has been captured correctly; can assign code reviewers afterwards.