### PR TITLE
Expand use of subfile type tags

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -1734,13 +1734,18 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
     }
     else {
       ifd.put(IFD.SOFTWARE, FormatTools.CREATOR);
+    }
 
-      if (resolution == 0) {
+    if (resolution == 0) {
+      if (!legacy) {
         ifd.put(IFD.SUB_IFD, (long) 0);
       }
-      else {
-        ifd.put(IFD.NEW_SUBFILE_TYPE, 1);
-      }
+      ifd.put(IFD.NEW_SUBFILE_TYPE, s.planeCount > 1 ? 2 : 0);
+      ifd.put(IFD.SUBFILE_TYPE, 1);
+    }
+    else {
+      ifd.put(IFD.NEW_SUBFILE_TYPE, s.planeCount > 1 ? 3 : 1);
+      ifd.put(IFD.SUBFILE_TYPE, 2);
     }
 
     // only write the OME-XML to the first full-resolution IFD


### PR DESCRIPTION
See pages 36 and 40-41 of https://www.itu.int/itudoc/itu-t/com16/tiff-fx/docs/tiff6.pdf.

This is an attempt at improving compatibility with other tools (e.g. Openslide) when using the `--legacy` option, and not intended to impact use of Bio-Formats/OMERO.

`tiffinfo` or `tiffdump` without this change on a file converted with `--legacy` should show that neither subfile tag was being written. When converting with this change and the same options, both subfile tags should be written for every IFD.