### PR TITLE
Bump bioformats2raw and zarr-java, removing libblosc dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,6 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
-      - name: Install libraries
-        run: |
-          sudo apt-get install -y libblosc1
       - name: Run commands
         run: |
           ./gradlew ${{ env.gradle_commands }}

--- a/README.md
+++ b/README.md
@@ -11,12 +11,6 @@ Requirements
 
 As of 0.10.0, Java 11 or later is required.
 
-libblosc (https://github.com/Blosc/c-blosc) version 1.9.0 or later must be installed separately.
-The native libraries are not packaged with any relevant jars.  See also note in jzarr readme (https://github.com/bcdev/jzarr/blob/master/README.md)
-
- * Mac OSX: `brew install c-blosc`
- * Ubuntu 18.04+: `apt-get install libblosc1`
-
 Installation
 ============
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://github.com/glencoesoftware/raw2ometiff/workflows/Gradle/badge.svg))](https://github.com/glencoesoftware/raw2ometiff/actions)
+[![Build status](https://github.com/glencoesoftware/raw2ometiff/workflows/Gradle/badge.svg)](https://github.com/glencoesoftware/raw2ometiff/actions)
 
 raw2ometiff converter
 =====================

--- a/build.gradle
+++ b/build.gradle
@@ -35,10 +35,10 @@ repositories {
 
 dependencies {
     implementation 'net.java.dev.jna:jna:5.10.0'
-    implementation 'dev.zarr:zarr-java:0.1.0'
+    implementation 'dev.zarr:zarr-java:0.1.3'
     implementation 'info.picocli:picocli:4.7.5'
     implementation 'ome:formats-bsd:8.5.0'
-    implementation 'com.glencoesoftware:bioformats2raw:0.12.0'
+    implementation 'com.glencoesoftware:bioformats2raw:0.12.1'
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.32'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'


### PR DESCRIPTION
Hey everyone,
 in line with https://github.com/glencoesoftware/bioformats2raw/pull/324 this bumps `bioformats2raw` to `0.12.1` and `zarr-java` to `0.1.3` while removing the `libblosc` system dependency for CI and in the README.md, inline with `bioformats2raw`.