### PR TITLE
Remove libblosc as a requirement of raw2ometiff

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,6 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
-      - name: Install libraries
-        run: |
-          sudo apt-get install -y libblosc1
       - name: Run commands
         run: |
           ./gradlew ${{ env.gradle_commands }}

--- a/README.md
+++ b/README.md
@@ -11,12 +11,6 @@ Requirements
 
 As of 0.10.0, Java 11 or later is required.
 
-libblosc (https://github.com/Blosc/c-blosc) version 1.9.0 or later must be installed separately.
-The native libraries are not packaged with any relevant jars.  See also note in jzarr readme (https://github.com/bcdev/jzarr/blob/master/README.md)
-
- * Mac OSX: `brew install c-blosc`
- * Ubuntu 18.04+: `apt-get install libblosc1`
-
 Installation
 ============
 


### PR DESCRIPTION
This extracts documentation changes regarding the `blosc` requirements included in #157. The requirement has been similarly removed in `bioformats2raw` - see https://github.com/glencoesoftware/bioformats2raw/pull/324

The migration from `jzarr` to `zarr-java` in [raw2ometiff 0.10.0](https://github.com/glencoesoftware/raw2ometiff/releases/tag/v0.10.0) includes the shipping of the blosc-java dependency which bundles pre-compiled blosc libraries for the different supported platforms and architectures.
