### PR TITLE
Fix handling of float/double data

### DIFF
--- a/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
+++ b/src/main/java/com/glencoesoftware/pyramid/PyramidFromDirectoryWriter.java
@@ -11,6 +11,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -721,8 +723,23 @@ public class PyramidFromDirectoryWriter implements Callable<Void> {
       ucar.ma2.Array tile = block.read(
         Utils.toLongArray(gridPosition),
         Utils.toLongArray(shape));
-      ByteBuffer buf = tile.getDataAsByteBuffer(
-        s.littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
+      ByteBuffer buf = null;
+      ByteOrder order =
+        s.littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN;
+      if (tile instanceof ucar.ma2.ArrayFloat) {
+        buf = tile.getDataAsByteBuffer((int) (4 * tile.getSize()), order);
+        FloatBuffer fb = buf.asFloatBuffer();
+        fb.put((float[]) tile.get1DJavaArray(float.class));
+      }
+      else if (tile instanceof ucar.ma2.ArrayDouble) {
+        buf = tile.getDataAsByteBuffer((int) (8 * tile.getSize()), order);
+        DoubleBuffer db = buf.asDoubleBuffer();
+        db.put((double[]) tile.get1DJavaArray(double.class));
+      }
+      else {
+        buf = tile.getDataAsByteBuffer(order);
+      }
+
       byte[] bytes = new byte[buf.remaining()];
       buf.get(bytes);
       return bytes;

--- a/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
@@ -94,6 +94,21 @@ public class ConversionTest {
     );
   }
 
+  static Stream<Arguments> getPixelTypeVersions() {
+    return Stream.of(
+      Arguments.of(V2_ARGUMENT, "uint8"),
+      Arguments.of(V2_ARGUMENT, "uint16"),
+      Arguments.of(V2_ARGUMENT, "uint32"),
+      Arguments.of(V2_ARGUMENT, "float"),
+      Arguments.of(V2_ARGUMENT, "double"),
+      Arguments.of(V3_ARGUMENT, "uint8"),
+      Arguments.of(V3_ARGUMENT, "uint16"),
+      Arguments.of(V3_ARGUMENT, "uint32"),
+      Arguments.of(V3_ARGUMENT, "float"),
+      Arguments.of(V3_ARGUMENT, "double")
+    );
+  }
+
   /**
    * Run the bioformats2raw main method and check for success or failure.
    *
@@ -370,11 +385,12 @@ public class ConversionTest {
    * Test defaults.
    *
    * @param version version parameter for bioformats2raw
+   * @param pixelType pixel type for input data (e.g. "uint8")
    */
   @ParameterizedTest
-  @MethodSource("getVersions")
-  public void testDefaults(String version) throws Exception {
-    input = fake();
+  @MethodSource("getPixelTypeVersions")
+  public void testDefaults(String version, String pixelType) throws Exception {
+    input = fake("pixelType", pixelType);
     assertBioFormats2Raw("--ngff-version", version);
     assertTool();
     assertDefaults(version);

--- a/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
+++ b/src/test/java/com/glencoesoftware/raw2ometiff/test/ConversionTest.java
@@ -96,13 +96,19 @@ public class ConversionTest {
 
   static Stream<Arguments> getPixelTypeVersions() {
     return Stream.of(
+      Arguments.of(V2_ARGUMENT, "int8"),
       Arguments.of(V2_ARGUMENT, "uint8"),
+      Arguments.of(V2_ARGUMENT, "int16"),
       Arguments.of(V2_ARGUMENT, "uint16"),
+      Arguments.of(V2_ARGUMENT, "int32"),
       Arguments.of(V2_ARGUMENT, "uint32"),
       Arguments.of(V2_ARGUMENT, "float"),
       Arguments.of(V2_ARGUMENT, "double"),
+      Arguments.of(V3_ARGUMENT, "int8"),
       Arguments.of(V3_ARGUMENT, "uint8"),
+      Arguments.of(V3_ARGUMENT, "int16"),
       Arguments.of(V3_ARGUMENT, "uint16"),
+      Arguments.of(V3_ARGUMENT, "int32"),
       Arguments.of(V3_ARGUMENT, "uint32"),
       Arguments.of(V3_ARGUMENT, "float"),
       Arguments.of(V3_ARGUMENT, "double")


### PR DESCRIPTION
Reported during testing of https://github.com/glencoesoftware/NGFF-Converter/pull/89.

559cb36 adds tests that include float and double data, which will fail if run without 4e95ec5.

The fix in 4e95ec5 works around the fact that `getDataAsByteBuffer(ByteOrder)` is not overridden in `ucar.ma2.ArrayFloat` and `ucar.ma2.ArrayDouble`. See:

- https://github.com/Unidata/netcdf-java/blob/maint-5.x/cdm/core/src/main/java/ucar/ma2/Array.java#L757
- https://github.com/Unidata/netcdf-java/blob/maint-5.x/cdm/core/src/main/java/ucar/ma2/ArrayDouble.java#L117
- https://github.com/Unidata/netcdf-java/blob/maint-5.x/cdm/core/src/main/java/ucar/ma2/ArrayFloat.java#L120
- https://github.com/Unidata/netcdf-java/blob/maint-5.x/cdm/core/src/main/java/ucar/ma2/ArrayInt.java#L129
- https://github.com/Unidata/netcdf-java/blob/maint-5.x/cdm/core/src/main/java/ucar/ma2/ArrayLong.java#L126

This appears to be an oversight; I propose to open an issue in [unidata/netcdf-java](https://github.com/Unidata/netcdf-java) as well unless any objection.